### PR TITLE
more fixes

### DIFF
--- a/core.c
+++ b/core.c
@@ -78,7 +78,7 @@ irqreturn_t mt76_irq_handler(int irq, void *dev_instance)
 	intr = mt76_rr(dev, MT_INT_SOURCE_CSR);
 	mt76_wr(dev, MT_INT_SOURCE_CSR, intr);
 
-	if (!test_bit(MT76_STATE_INITAILIZED, &dev->state))
+	if (!test_bit(MT76_STATE_INITIALIZED, &dev->state))
 		return IRQ_NONE;
 
 	trace_dev_irq(dev, intr, dev->irqmask);

--- a/init.c
+++ b/init.c
@@ -507,7 +507,7 @@ int mt76_init_hardware(struct mt76_dev *dev)
 	if (ret)
 		return ret;
 
-	set_bit(MT76_STATE_INITAILIZED, &dev->state);
+	set_bit(MT76_STATE_INITIALIZED, &dev->state);
 	ret = mt76_mac_start(dev);
 	if (ret)
 		return ret;

--- a/mcu.c
+++ b/mcu.c
@@ -161,7 +161,7 @@ mt76pci_load_rom_patch(struct mt76_dev *dev)
 	}
 
 	hdr = (struct mt76_patch_header *) fw->data;
-	printk("ROM patch build: %15s\n", hdr->build_time);
+	printk("ROM patch build: %.15s\n", hdr->build_time);
 
 	mt76_wr(dev, MT_MCU_PCIE_REMAP_BASE4, MT_MCU_ROM_PATCH_OFFSET);
 
@@ -217,7 +217,7 @@ mt76pci_load_firmware(struct mt76_dev *dev)
 
 	val = le16_to_cpu(hdr->build_ver);
 	printk("Build: %x\n", val);
-	printk("Build Time: %16s\n", hdr->build_time);
+	printk("Build Time: %.16s\n", hdr->build_time);
 
 	cur = (__le32 *) (fw->data + sizeof(*hdr));
 	len = le32_to_cpu(hdr->ilm_len);

--- a/mt76.h
+++ b/mt76.h
@@ -58,7 +58,7 @@ struct mt76_queue_entry {
 };
 
 enum {
-	MT76_STATE_INITAILIZED,
+	MT76_STATE_INITIALIZED,
 	MT76_STATE_RUNNING,
 	MT76_SCANNING,
 };

--- a/regs.h
+++ b/regs.h
@@ -425,8 +425,9 @@
 #define MT_TX_AGG_CNT_BASE0		0x1720
 #define MT_TX_AGG_CNT_BASE1		0x174c
 
-#define MT_TX_AGG_CNT(_id)		(((_id) > 7 ? MT_TX_AGG_CNT_BASE1 : \
-					  MT_TX_AGG_CNT_BASE0) + ((_id) << 2))
+#define MT_TX_AGG_CNT(_id)		((_id) < 8 ?			\
+					 MT_TX_AGG_CNT_BASE0 + ((_id) << 2) : \
+					 MT_TX_AGG_CNT_BASE1 + ((_id - 8) << 2))
 
 #define MT_TX_STAT_FIFO_EXT		0x1798
 #define MT_TX_STAT_FIFO_EXT_RETRY	GENMASK(7, 0)


### PR DESCRIPTION
This time I offer corrections for errors I found while using some of the code in my own driver. I correct a bug introduced in the previous batch by using field width instead of precision to limit the length of strings read from firmware header. Apart from that there is a correction of aggregation statistics' offsets and a spelling fix.
