### PR TITLE
fixes #3

### DIFF
--- a/dma.c
+++ b/dma.c
@@ -239,7 +239,7 @@ int mt76_tx_queue_skb(struct mt76_dev *dev, struct mt76_queue *q,
 		  MT76_SET(MT_TXD_INFO_QSEL, qsel) |
 		  MT_TXD_INFO_80211;
 
-	if (!wcid || wcid->hw_key_idx < 0)
+	if (!wcid || wcid->hw_key_idx == 0xff)
 		tx_info |= MT_TXD_INFO_WIV;
 
 	addr = dma_map_single(dev->dev, skb->data, skb->len, DMA_TO_DEVICE);

--- a/mcu.c
+++ b/mcu.c
@@ -267,7 +267,8 @@ error:
 	return -ENOENT;
 }
 
-int mt76_mcu_function_select(struct mt76_dev *dev, enum mcu_function func, u32 val)
+static int
+mt76_mcu_function_select(struct mt76_dev *dev, enum mcu_function func, u32 val)
 {
 	struct sk_buff *skb;
 	struct {

--- a/mt76.h
+++ b/mt76.h
@@ -74,7 +74,7 @@ enum mt76_txq_id {
 };
 
 struct mt76_queue {
-	struct mt76_queue_regs *regs;
+	struct mt76_queue_regs __iomem *regs;
 
 	spinlock_t lock;
 	struct mt76_queue_entry *entry;

--- a/phy.c
+++ b/phy.c
@@ -184,7 +184,7 @@ static bool
 mt76_phy_tssi_init_cal(struct mt76_dev *dev)
 {
 	struct ieee80211_channel *chan = dev->chandef.chan;
-	u16 flag = 0;
+	u32 flag = 0;
 
 	if (!mt76_tssi_enabled(dev))
 		return false;

--- a/phy.c
+++ b/phy.c
@@ -341,7 +341,7 @@ mt76_phy_set_bw(struct mt76_dev *dev, int width, u8 ctrl)
 	}
 
 	mt76_rmw_field(dev, MT_BBP(CORE, 1), MT_BBP_CORE_R1_BW, core_val);
-	mt76_rmw_field(dev, MT_BBP(AGC, 0), MT_BBP_AGC_R0_BW, core_val);
+	mt76_rmw_field(dev, MT_BBP(AGC, 0), MT_BBP_AGC_R0_BW, agc_val);
 	mt76_rmw_field(dev, MT_BBP(AGC, 0), MT_BBP_AGC_R0_CTRL_CHAN, ctrl);
 	mt76_rmw_field(dev, MT_BBP(TXBE, 0), MT_BBP_TXBE_R0_CTRL_CHAN, ctrl);
 }


### PR DESCRIPTION
Hello!
I started digging into mt7630e support this morning and found some issues with mt76 when built with `C=1 W=1`. All 5 are one-liners and pretty trivial. Please consider pulling.
Cheers,
Kuba