### PR TITLE
Update mt7603_main.c missing #include <linux/module.h>

### DIFF
--- a/mt7603_main.c
+++ b/mt7603_main.c
@@ -14,6 +14,7 @@
 #include <linux/etherdevice.h>
 #include <linux/platform_device.h>
 #include <linux/pci.h>
+#include <linux/module.h>
 #include "mt7603.h"
 #include "mt7603_eeprom.h"
 


### PR DESCRIPTION
compile error.
`mt7603_main.c:527:16: error: expected declaration specifiers or '...' before string constant
 MODULE_LICENSE("GPL");
                ^
`

missing `#include <linux/module.h>`