### PR TITLE
Add 14c3:7612 device ID

### DIFF
--- a/mt76x2_pci.c
+++ b/mt76x2_pci.c
@@ -20,6 +20,7 @@
 
 static const struct pci_device_id mt76pci_device_table[] = {
 	{ PCI_DEVICE(0x14c3, 0x7662) },
+	{ PCI_DEVICE(0x14c3, 0x7612) },
 	{ },
 };
 


### PR DESCRIPTION
MT7602EN chip on SamKnows Whitebox 8 (SK-WB8) hardware reports a device ID of 14c3:7612.

Confirmed working with mt76:

01:00.0 Network controller [0280]: MEDIATEK Corp. Device [14c3:7612]
	Subsystem: MEDIATEK Corp. Device [14c3:7612]
	Kernel driver in use: mt76x2e

root@OpenWrt:~# cat /sys/kernel/debug/ieee80211/phy0/mt76/txpower 
Target power: 33
     Delta: -2 -2
       CCK:  3  3  3  3
      OFDM:  3  3  3  3  2  2  2  2
        HT:  3  3  3  3  2  2  2  2  3  3  3  3  2  2  0  0
       VHT:  2  2  2  2  2  2  2  2 -1 -1