### PR TITLE
mt76x2: choose RX gain type based on RF layout

### DIFF
--- a/mt76x2_eeprom.c
+++ b/mt76x2_eeprom.c
@@ -354,12 +354,14 @@ void mt76x2_read_rx_gain(struct mt76x2_dev *dev)
 	u8 lna;
 	u16 val;
 
-	if (chan->band == NL80211_BAND_2GHZ)
+	if (chan->band == NL80211_BAND_2GHZ) {
 		val = mt76x2_eeprom_get(dev, MT_EE_RF_2G_RX_HIGH_GAIN) >> 8;
-	else
+	} else if (mt76x2_eeprom_get(dev, MT_EE_WIFI_EXT) & MT_EE_WIFI_EXT_COMP) {
 		val = mt76x2_get_5g_rx_gain(dev, channel);
-
-	mt76x2_set_rx_gain_group(dev, val);
+		mt76x2_set_rx_gain_group(dev, val);
+	} else {
+		val = mt76x2_eeprom_get(dev, MT_EE_RF_2G_RX_HIGH_GAIN);
+	}
 
 	if (chan->band == NL80211_BAND_2GHZ) {
 		val = mt76x2_eeprom_get(dev, MT_EE_RSSI_OFFSET_2G_0);

--- a/mt76x2_eeprom.h
+++ b/mt76x2_eeprom.h
@@ -23,6 +23,7 @@ enum mt76x2_eeprom_field {
 	MT_EE_CHIP_ID =				0x000,
 	MT_EE_VERSION =				0x002,
 	MT_EE_MAC_ADDR =			0x004,
+	MT_EE_WIFI_EXT =			0x025,
 	MT_EE_NIC_CONF_0 =			0x034,
 	MT_EE_NIC_CONF_1 =			0x036,
 	MT_EE_NIC_CONF_2 =			0x042,
@@ -82,6 +83,8 @@ enum mt76x2_eeprom_field {
 
 	__MT_EE_MAX
 };
+
+#define MT_EE_WIFI_EXT_COMP			BIT(6)
 
 #define MT_EE_NIC_CONF_0_PA_INT_2G		BIT(8)
 #define MT_EE_NIC_CONF_0_PA_INT_5G		BIT(9)


### PR DESCRIPTION
Allows reading an RF layout data from EEPROM and choice between RX_HIGH_GAIN groups for ePA/eLNA design or TSSI_OFF_TXPOWER for iPA/iLNA design.

Signed-off-by: Tomislav Požega <pozega.tomislav@gmail.com>