### PR TITLE
mt76x2: init: enable status led by default

### DIFF
--- a/mt76x2_init.c
+++ b/mt76x2_init.c
@@ -157,6 +157,7 @@ mt76_write_mac_initvals(struct mt76x2_dev *dev)
 		{ MT_VHT_HT_FBK_CFG1,		0xedcba980 },
 		{ MT_PROT_AUTO_TX_CFG,		0x00830083 },
 		{ MT_HT_CTRL_CFG,		0x000001ff },
+		{ MT_MCU_LED_CTRL,		0x00840000 },
 	};
 	struct mt76x2_reg_pair prot_vals[] = {
 		{ MT_CCK_PROT_CFG,		DEFAULT_PROT_CFG },


### PR DESCRIPTION
Modify in accordance with infomation on following URL, and test ok on my Phicomm PSG1208
https://github.com/openwrt/mt76/issues/54
https://github.com/openwrt/mt76/issues/55