### PR TITLE
mt76x2: Support using PCI ID as chip ID

### DIFF
--- a/mt7603_mac.c
+++ b/mt7603_mac.c
@@ -1178,9 +1178,9 @@ static bool mt7603_rx_dma_busy(struct mt7603_dev *dev)
 	if (!(mt76_rr(dev, MT_WPDMA_GLO_CFG) & MT_WPDMA_GLO_CFG_RX_DMA_BUSY))
 		return false;
 
-	mt76_wr(dev, 0x4244, 0x98000000);
+	mt76_wr(dev, 0x4244, 0x28000000);
 	val = mt76_rr(dev, 0x4244);
-	return !!(val & BIT(9));
+	return !!(val & BIT(8));
 }
 
 static bool mt7603_tx_dma_busy(struct mt7603_dev *dev)

--- a/mt76x2_eeprom.c
+++ b/mt76x2_eeprom.c
@@ -205,6 +205,9 @@ static int mt76x2_check_eeprom(struct mt76x2_dev *dev)
 {
 	u16 val = get_unaligned_le16(dev->mt76.eeprom.data);
 
+	if (!val)
+		val = get_unaligned_le16(dev->mt76.eeprom.data + MT_EE_PCI_ID);
+
 	switch (val) {
 	case 0x7662:
 	case 0x7612:

--- a/mt76x2_eeprom.h
+++ b/mt76x2_eeprom.h
@@ -23,6 +23,7 @@ enum mt76x2_eeprom_field {
 	MT_EE_CHIP_ID =				0x000,
 	MT_EE_VERSION =				0x002,
 	MT_EE_MAC_ADDR =			0x004,
+	MT_EE_PCI_ID =				0x00A,
 	MT_EE_NIC_CONF_0 =			0x034,
 	MT_EE_NIC_CONF_1 =			0x036,
 	MT_EE_NIC_CONF_2 =			0x042,


### PR DESCRIPTION
On some routers, the manufacturer has made a mistake and left the chip
ID part of the EEPROM empty (it is set to 0x0000). One such router is
the ZBT-WE1026-5G (equipped with MT7612), and the consequence is that
the EEPROM check fails and the 5GHz wifi does not work at all. When
setting the chip ID to 0x7612 manually, the 5GHz wifi works fine.

When looking at EEPROM of the WE1026 (and other devices equipped with
mt76x2), I see that the PCI ID is always set to a valid value (7612 or
7662). This PR works around the issue of an empty chip ID by using the
PCI ID, if chip ID is 0. After applying this PR/patch manually to mt76,
the 5GHz on the WE1026 works out of the box. Since the PCI ID is only
used if chip ID is empty, devices with correct EEPROMs are not affected.