### PR TITLE
mt76x2: Add PCI identifier for MT7602

### DIFF
--- a/mt76x2_pci.c
+++ b/mt76x2_pci.c
@@ -24,6 +24,7 @@
 static const struct pci_device_id mt76pci_device_table[] = {
 	{ PCI_DEVICE(0x14c3, 0x7662) },
 	{ PCI_DEVICE(0x14c3, 0x7612) },
+	{ PCI_DEVICE(0x14c3, 0x7602) },
 	{ },
 };
 


### PR DESCRIPTION
MT7602 is also available as a PCI card, so add the missing identifier.

Signed-off-by: Kristian Evensen <kristian.evensen@gmail.com>