### PR TITLE
mt76x0: eeprom: add support for MAC address from OF

### DIFF
--- a/mt76x0/eeprom.c
+++ b/mt76x0/eeprom.c
@@ -336,6 +336,7 @@ int mt76x0_eeprom_init(struct mt76x02_dev *dev)
 		 version, fae);
 
 	mt76x02_mac_setaddr(dev, dev->mt76.eeprom.data + MT_EE_MAC_ADDR);
+	mt76_eeprom_override(&dev->mt76);
 	mt76x0_set_chip_cap(dev);
 	mt76x0_set_freq_offset(dev);
 	mt76x0_set_temp_offset(dev);


### PR DESCRIPTION
mt76x0e driver support only MAC address from
calibration data eeprom. Many routers have
stock address in this field.

This patch make possible to take mac address
from OF (e.g. from mtd)

Tested on D-Link DWR-118 A1 (MT7610EN)

Signed-off-by: Pawel Dembicki <paweldembicki@gmail.com>