### PR TITLE
mt7603: apply efuse data only when it exists

### DIFF
--- a/mt7603/eeprom.c
+++ b/mt7603/eeprom.c
@@ -165,11 +165,13 @@ int mt7603_eeprom_init(struct mt7603_dev *dev)
 	if (ret < 0)
 		return ret;
 
-	if (mt7603_check_eeprom(&dev->mt76) == 0)
-		mt7603_apply_cal_free_data(dev, dev->mt76.otp.data);
-	else
-		memcpy(dev->mt76.eeprom.data, dev->mt76.otp.data,
-		       MT7603_EEPROM_SIZE);
+	if (dev->mt76.otp.data) {
+		if (mt7603_check_eeprom(&dev->mt76) == 0)
+			mt7603_apply_cal_free_data(dev, dev->mt76.otp.data);
+		else
+			memcpy(dev->mt76.eeprom.data, dev->mt76.otp.data,
+			       MT7603_EEPROM_SIZE);
+	}
 
 	dev->mt76.cap.has_2ghz = true;
 	memcpy(dev->mt76.macaddr, dev->mt76.eeprom.data + MT_EE_MAC_ADDR,


### PR DESCRIPTION
Some mt7603e chip has empty efuse data.
In this case driver will crash due to dereferencing NULL pointer.

The mt7603_eeprom_load will return success directly if the chip has no efuse
data and dev->mt76.otp.data is left empty, i.e. NULL pointer.
The mt7603_eeprom_init will then try to dereference dev->mt76.otp.data
without checking its value.

This patch adds a check around these codes to prevent kernel panic.

Signed-off-by: Weijie Gao <hackpascal@gmail.com>