### PR TITLE
mt76: introduce mt76x02_config_mac_addr routine

### DIFF
--- a/mt76x0/init.c
+++ b/mt76x0/init.c
@@ -289,7 +289,7 @@ int mt76x0_register_device(struct mt76x02_dev *dev)
 	int ret;
 
 	mt76x02_init_device(dev);
-	mt76x02_config_mac_addr_list(dev);
+	mt76x02_config_mac_addr(dev);
 
 	ret = mt76_register_device(&dev->mt76, true, mt76x02_rates,
 				   ARRAY_SIZE(mt76x02_rates));

--- a/mt76x02.h
+++ b/mt76x02.h
@@ -71,8 +71,6 @@ struct mt76x02_calibration {
 struct mt76x02_dev {
 	struct mt76_dev mt76; /* must be first */
 
-	struct mac_address macaddr_list[8];
-
 	struct mutex phy_mutex;
 
 	u16 vif_mask;
@@ -136,7 +134,7 @@ int mt76x02_sta_add(struct mt76_dev *mdev, struct ieee80211_vif *vif,
 void mt76x02_sta_remove(struct mt76_dev *mdev, struct ieee80211_vif *vif,
 			struct ieee80211_sta *sta);
 
-void mt76x02_config_mac_addr_list(struct mt76x02_dev *dev);
+void mt76x02_config_mac_addr(struct mt76x02_dev *dev);
 
 int mt76x02_add_interface(struct ieee80211_hw *hw,
 			 struct ieee80211_vif *vif);

--- a/mt76x02_util.c
+++ b/mt76x02_util.c
@@ -738,26 +738,13 @@ void mt76x02_bss_info_changed(struct ieee80211_hw *hw,
 }
 EXPORT_SYMBOL_GPL(mt76x02_bss_info_changed);
 
-void mt76x02_config_mac_addr_list(struct mt76x02_dev *dev)
+void mt76x02_config_mac_addr(struct mt76x02_dev *dev)
 {
 	struct ieee80211_hw *hw = mt76_hw(dev);
 	struct wiphy *wiphy = hw->wiphy;
-	int i;
 
-	for (i = 0; i < ARRAY_SIZE(dev->macaddr_list); i++) {
-		u8 *addr = dev->macaddr_list[i].addr;
-
-		memcpy(addr, dev->mt76.macaddr, ETH_ALEN);
-
-		if (!i)
-			continue;
-
-		addr[0] |= BIT(1);
-		addr[0] ^= ((i - 1) << 2);
-	}
-	wiphy->addresses = dev->macaddr_list;
-	wiphy->n_addresses = ARRAY_SIZE(dev->macaddr_list);
+	memcpy(wiphy->perm_addr, dev->mt76.macaddr, ETH_ALEN);
 }
-EXPORT_SYMBOL_GPL(mt76x02_config_mac_addr_list);
+EXPORT_SYMBOL_GPL(mt76x02_config_mac_addr);
 
 MODULE_LICENSE("Dual BSD/GPL");

--- a/mt76x2/pci_init.c
+++ b/mt76x2/pci_init.c
@@ -318,7 +318,7 @@ int mt76x2_register_device(struct mt76x02_dev *dev)
 	if (ret)
 		return ret;
 
-	mt76x02_config_mac_addr_list(dev);
+	mt76x02_config_mac_addr(dev);
 
 	ret = mt76_register_device(&dev->mt76, true, mt76x02_rates,
 				   ARRAY_SIZE(mt76x02_rates));


### PR DESCRIPTION
This change mt76x02_config_mac_addr_list routine to mt76x02_config_mac_addr
just set the wiphy->perm_addr instead of mac address list

In order to support the mac-setup by hotplug script like those
in ath79 and other platform, so that we can set a custom mac by:
  echo XX:XX:XX:XX:XX:XX >/sys/devices/platform/.../ieee80211/phy0/macaddress

I don't know why we setup mac list, but just setup the perm_addr in wiphy seems to be OK

Related discussions and support are here https://github.com/openwrt/mt76/issues/219
