### PR TITLE
Remove 5GHz definitions from mt7603 driver

### DIFF
--- a/mt7603/init.c
+++ b/mt7603/init.c
@@ -459,7 +459,7 @@ static void
 mt7603_init_txpower(struct mt7603_dev *dev)
 {
 	struct ieee80211_channel *chan;
-	struct ieee80211_supported_band sband = &dev->mt76.sband_2g.sband;
+	struct ieee80211_supported_band *sband = &dev->mt76.sband_2g.sband;
 	u8 *eeprom = (u8 *)dev->mt76.eeprom.data;
 	int target_power = eeprom[MT_EE_TX_POWER_0_START_2G + 2] & ~BIT(7);
 	u8 *rate_power = &eeprom[MT_EE_TX_POWER_CCK];

--- a/mt7603/init.c
+++ b/mt7603/init.c
@@ -456,10 +456,10 @@ mt7603_txpower_signed(int val)
 }
 
 static void
-mt7603_init_txpower(struct mt7603_dev *dev,
-		    struct ieee80211_supported_band *sband)
+mt7603_init_txpower(struct mt7603_dev *dev)
 {
 	struct ieee80211_channel *chan;
+	struct ieee80211_supported_band sband = &dev->mt76.sband_2g.sband;
 	u8 *eeprom = (u8 *)dev->mt76.eeprom.data;
 	int target_power = eeprom[MT_EE_TX_POWER_0_START_2G + 2] & ~BIT(7);
 	u8 *rate_power = &eeprom[MT_EE_TX_POWER_CCK];
@@ -564,7 +564,7 @@ int mt7603_register_device(struct mt7603_dev *dev)
 		return ret;
 
 	mt7603_init_debugfs(dev);
-	mt7603_init_txpower(dev, &dev->mt76.sband_2g.sband);
+	mt7603_init_txpower(dev);
 
 	return 0;
 }

--- a/mt7603/mac.c
+++ b/mt7603/mac.c
@@ -401,9 +401,9 @@ void mt7603_mac_tx_ba_reset(struct mt7603_dev *dev, int wcid, int tid, int ssn,
 }
 
 static int
-mt7603_get_rate(struct mt7603_dev *dev, struct ieee80211_supported_band *sband,
-		int idx, bool cck)
+mt7603_get_rate(struct mt7603_dev *dev, int idx, bool cck)
 {
+	struct ieee80211_supported_band *sband = &dev->mt76.sband_2g.sband;
 	int offset = 0;
 	int len = sband->n_bitrates;
 	int i;
@@ -557,7 +557,7 @@ mt7603_mac_fill_rx(struct mt7603_dev *dev, struct sk_buff *skb)
 			cck = true;
 			/* fall through */
 		case MT_PHY_TYPE_OFDM:
-			i = mt7603_get_rate(dev, sband, i, cck);
+			i = mt7603_get_rate(dev, i, cck);
 			break;
 		case MT_PHY_TYPE_HT_GF:
 		case MT_PHY_TYPE_HT:
@@ -970,7 +970,6 @@ static bool
 mt7603_fill_txs(struct mt7603_dev *dev, struct mt7603_sta *sta,
 		struct ieee80211_tx_info *info, __le32 *txs_data)
 {
-	struct ieee80211_supported_band *sband;
 	int final_idx = 0;
 	u32 final_rate;
 	u32 final_rate_flags;
@@ -1053,9 +1052,8 @@ out:
 		cck = true;
 		/* fall through */
 	case MT_PHY_TYPE_OFDM:
-		sband = &dev->mt76.sband_2g.sband;
 		final_rate &= GENMASK(5, 0);
-		final_rate = mt7603_get_rate(dev, sband, final_rate, cck);
+		final_rate = mt7603_get_rate(dev, final_rate, cck);
 		final_rate_flags = 0;
 		break;
 	case MT_PHY_TYPE_HT_GF:

--- a/mt7603/main.c
+++ b/mt7603/main.c
@@ -127,7 +127,7 @@ mt7603_init_edcca(struct mt7603_dev *dev)
 static int
 mt7603_set_channel(struct mt7603_dev *dev, struct cfg80211_chan_def *def)
 {
-	u8 *rssi_data = (u8 *)dev->mt76.eeprom.data;
+	u8 *rssi_data = ((u8 *)dev->mt76.eeprom.data) + MT_EE_RSSI_OFFSET_2G;
 	int idx, ret;
 	u8 bw = MT_BW_20;
 	bool failed = false;
@@ -151,17 +151,9 @@ mt7603_set_channel(struct mt7603_dev *dev, struct cfg80211_chan_def *def)
 		goto out;
 	}
 
-	if (def->chan->band == NL80211_BAND_5GHZ) {
-		idx = 1;
-		rssi_data += MT_EE_RSSI_OFFSET_5G;
-	} else {
-		idx = 0;
-		rssi_data += MT_EE_RSSI_OFFSET_2G;
-	}
-
 	memcpy(dev->rssi_offset, rssi_data, sizeof(dev->rssi_offset));
 
-	idx |= (def->chan -
+	idx = (def->chan -
 		mt76_hw(dev)->wiphy->bands[def->chan->band]->channels) << 1;
 	mt76_wr(dev, MT_WF_RMAC_CH_FREQ, idx);
 	mt7603_mac_set_timing(dev);


### PR DESCRIPTION
Hardware does not support 5GHz band, so we could cleanup the code.