### PR TITLE
mt76x2u: Add device ID for the new Xbox One wireless adapter (045e:02fe)

### DIFF
--- a/mt76x02.h
+++ b/mt76x02.h
@@ -220,6 +220,7 @@ static inline bool is_mt76x2(struct mt76x02_dev *dev)
 {
 	return mt76_chip(&dev->mt76) == 0x7612 ||
 	       mt76_chip(&dev->mt76) == 0x7662 ||
+	       mt76_chip(&dev->mt76) == 0x7632 ||
 	       mt76_chip(&dev->mt76) == 0x7602;
 }
 

--- a/mt76x2/usb.c
+++ b/mt76x2/usb.c
@@ -29,6 +29,7 @@ static const struct usb_device_id mt76x2u_device_table[] = {
 	{ USB_DEVICE(0x7392, 0xb711) },	/* Edimax EW 7722 UAC */
 	{ USB_DEVICE(0x0846, 0x9053) },	/* Netgear A6210 */
 	{ USB_DEVICE(0x045e, 0x02e6) },	/* XBox One Wireless Adapter */
+	{ USB_DEVICE(0x045e, 0x02fe) },	/* XBox One Wireless Adapter v2 */
 	{ },
 };
 


### PR DESCRIPTION
The adapter is based on MT7632U.