### PR TITLE
mt76: eeprom: fix return value check in mt76_eeprom_override()

### DIFF
--- a/eeprom.c
+++ b/eeprom.c
@@ -86,7 +86,7 @@ mt76_eeprom_override(struct mt76_dev *dev)
 		return;
 
 	mac = of_get_mac_address(np);
-	if (mac)
+	if (mac && !IS_ERR(mac))
 		memcpy(dev->macaddr, mac, ETH_ALEN);
 #endif
 


### PR DESCRIPTION
According to hauke/backports@fcf0940dcd3ac6cd98a1d062202d8f482a0f519e:

> The behavior of of_get_mac_address() changed in kernel 5.2, it now
returns an error code and not NULL in case of an error.

This change causes a kernel panic in recent OpenWrt builds.
```
[    9.957796] CPU 0 Unable to handle kernel paging request at virtual address fffffff0, epc == 82ea34f8, ra == 82ea34ec
...
[   10.367850] Call Trace:
[   10.372688] [<82ea34f8>] mt76_eeprom_override+0x38/0xdc [mt76]
[   10.384275] [<82897594>] mt7603_eeprom_init+0x2e4/0x504 [mt7603e]
[   10.396358] [<82891cac>] mt7603_register_device+0x12c/0xb84 [mt7603e]
[   10.409130] [<82890328>] init_module+0xc328/0xd20c [mt7603e]
```

See #299