### PR TITLE
mt7603: use eeprom 0x34 to get antenna number for mt7628.

### DIFF
--- a/mt7603/init.c
+++ b/mt7603/init.c
@@ -277,6 +277,9 @@ mt7603_init_hardware(struct mt7603_dev *dev)
 	if (ret < 0)
 		return ret;
 
+	if (((u8*)dev->mphy.eeprom.data)[MT_EE_NIC_CONF_0] == 0x11)
+		dev->mphy.antenna_mask = 1;
+
 	ret = mt7603_dma_init(dev);
 	if (ret)
 		return ret;


### PR DESCRIPTION
MT7628 can work both in 1T1R and 2T2R mode, and that can be setup in eeprom at 0x34 address. This patch fix some devices who only have one antenna can not send data stably in 2T2R.

Signed-off-by: Qin Wei <me@vonger.cn>