### PR TITLE
mt76x2u: util: unlock DFS channels

### DIFF
--- a/mt76x02_util.c
+++ b/mt76x02_util.c
@@ -89,6 +89,10 @@ static const struct ieee80211_iface_combination mt76x02u_if_comb[] = {
 		.max_interfaces = 2,
 		.num_different_channels = 1,
 		.beacon_int_infra_match = true,
+                .radar_detect_widths = BIT(NL80211_CHAN_WIDTH_20_NOHT) |
+                                       BIT(NL80211_CHAN_WIDTH_20) |
+                                       BIT(NL80211_CHAN_WIDTH_40) |
+                                       BIT(NL80211_CHAN_WIDTH_80),
 	}
 };
 


### PR DESCRIPTION
enables DFS channels on mt76x2u devices. Tested on COMFAST CF-WU782AC.

Credit goes to Lorenzo Bianconi
modification of https://github.com/openwrt/mt76/commit/b9f3193a2438ecc6807fe1600272536fb7ff5745

Signed-off-by: Yushi Nishida kyro2man@gmx.net