### PR TITLE
[PATCH] mt7603

### DIFF
--- a/mt7603/eeprom.c
+++ b/mt7603/eeprom.c
@@ -136,6 +136,7 @@ static int mt7603_check_eeprom(struct mt76_dev *dev)
 	switch (val) {
 	case 0x7628:
 	case 0x7603:
+	case 0x7600:		
 		return 0;
 	default:
 		return -EINVAL;


### PR DESCRIPTION
allow eeprom sections starting with 7600 Fixes low
 signal issue for 2.4 GHz for the TP-Link Archer C50 v4. The first two bytes
 in the eeprom are the chip id. The working devices have 0x7628 there, whereas
 the non-working devices have 0x7600 there. This chip id gets checked by the
 function mt7603_check_eeprom() which leads the driver to ignore the contents
 of the eeprom partition and load default values from otp.