### PR TITLE
mt7610e external frontend patch

### DIFF
--- a/mt76x0/phy.c
+++ b/mt76x0/phy.c
@@ -467,6 +467,11 @@ static void mt76x0_phy_ant_select(struct mt76x02_dev *dev)
 	mt76_rmw(dev, MT_CSR_EE_CFG1, GENMASK(15, 0), ee_cfg1);
 	mt76_clear(dev, MT_COEXCFG0, BIT(2));
 	mt76_wr(dev, MT_COEXCFG3, coex3);
+
+	u32 xo1 = mt76_rr(dev, MT_XO_CTRL1);
+	xo1 &= 0xffff0000;
+	xo1 |= (u32)ee_cfg1;
+	mt76_wr(dev, MT_XO_CTRL1, xo1);
 }
 
 static void


### PR DESCRIPTION
Ported from: https://github.com/openwrt/mt76/issues/286

Should fix:
https://github.com/openwrt/mt76/issues/199
https://github.com/openwrt/mt76/issues/227

At least fix problem on DIR-510L with 5GHz: clients most times can not connect.
Detailed issue description #227

Also this duplicates: https://github.com/openwrt/mt76/pull/287
but current code base does not have these changes.