### PR TITLE
tools: Set mode for new file /tmp/mt76-test-%s

### DIFF
--- a/tools/eeprom.c
+++ b/tools/eeprom.c
@@ -77,7 +77,7 @@ mt76_eeprom_create_file(void)
 		return -1;
 	}
 
-	fd = open(eeprom_file, O_RDWR | O_CREAT | O_EXCL);
+	fd = open(eeprom_file, O_RDWR | O_CREAT | O_EXCL, 00644);
 	if (fd < 0)
 		goto out;
 


### PR DESCRIPTION
Set the file system mode for the newly created file /tmp/mt76-test-%s,
this is mandatory according to the man page and fixes a compile error
with glibc.

Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>