### PR TITLE
mt76: mt7915: fix struct ieee80211_iface_limit

### DIFF
--- a/mt7915/init.c
+++ b/mt7915/init.c
@@ -40,9 +40,9 @@ static const struct ieee80211_iface_limit if_limits[] = {
 		.types = BIT(NL80211_IFTYPE_ADHOC)
 	}, {
 		.max = 16,
-		.types = BIT(NL80211_IFTYPE_AP) |
+		.types = BIT(NL80211_IFTYPE_AP)
 #ifdef CONFIG_MAC80211_MESH
-			 BIT(NL80211_IFTYPE_MESH_POINT)
+			 | BIT(NL80211_IFTYPE_MESH_POINT)
 #endif
 	}, {
 		.max = MT7915_MAX_INTERFACES,


### PR DESCRIPTION
Fixes following compiler error:

 mt7915/init.c:47:2: error: expected expression before '}' token

Fixes: 2741fd071bb7 ("mt76: mt7915: support 32 station interfaces")
Signed-off-by: Petr Štetiar <ynezz@true.cz>