### PR TITLE
mt76: mt7603: add additional EEPROM chip ID

### DIFF
--- a/mt7603/eeprom.c
+++ b/mt7603/eeprom.c
@@ -136,6 +136,7 @@ static int mt7603_check_eeprom(struct mt76_dev *dev)
 	switch (val) {
 	case 0x7628:
 	case 0x7603:
+	case 0x7600:
 		return 0;
 	default:
 		return -EINVAL;


### PR DESCRIPTION
Some newer MT7628 based routers (notably the TP-Link Archer C50 v4) are
shipped with a chip-id of 0x7600 in the on-flash EEPROM. Add this as a
possible valid ID.

Ref: https://bugs.openwrt.org/index.php?do=details&task_id=2781

Suggested-by: Ron Asimi <ron.asimi@gmail.com>
Signed-off-by: David Bauer <mail@david-bauer.net>