### PR TITLE
mt76: mt7615: load EEPROMs for MT7613BE

### DIFF
--- a/mt7615/eeprom.c
+++ b/mt7615/eeprom.c
@@ -86,6 +86,7 @@ static int mt7615_check_eeprom(struct mt76_dev *dev)
 	switch (val) {
 	case 0x7615:
 	case 0x7622:
+	case 0x7663:
 		return 0;
 	default:
 		return -EINVAL;


### PR DESCRIPTION
EEPROM blobs for MT7613BE start with (little endian) 0x7663, which is also the PCI device ID for this device. The EEPROM is required for the radio to work at useful power levels, otherwise only the lowest power level is available.