### PR TITLE
eeprom: support reading EEPROM data embedded in fdt

### DIFF
--- a/eeprom.c
+++ b/eeprom.c
@@ -15,6 +15,7 @@ int mt76_get_of_eeprom(struct mt76_dev *dev, void *eep, int offset, int len)
 	struct device_node *np = dev->dev->of_node;
 	struct mtd_info *mtd;
 	const __be32 *list;
+	const void *data;
 	const char *part;
 	phandle phandle;
 	int size;
@@ -23,6 +24,16 @@ int mt76_get_of_eeprom(struct mt76_dev *dev, void *eep, int offset, int len)
 
 	if (!np)
 		return -ENOENT;
+
+	data = of_get_property(np, "mediatek,eeprom-data", &size);
+	if (data) {
+		if (size > len)
+			return -EINVAL;
+
+		memcpy(eep, data, size);
+
+		return 0;
+	}
 
 	list = of_get_property(np, "mediatek,mtd-eeprom", &size);
 	if (!list)


### PR DESCRIPTION
Some boards booting from SD card don't come with calibration data stored anywhere on the board.
As EEPROM data is rather small it can be embedded into the device tree to be loaded from there by the mt76.

Signed-off-by: Daniel Golle <daniel@makrotopia.org>

Example device tree snippet for BananaPi BPi-R64:
```
&wmac {
        mediatek,eeprom-data = <0x22760500      0x0             0x0             0x0
                                0x0             0x0             0x0             0x0
                                0x0             0x0             0x0             0x0
                                0x0             0x44000020      0x0             0x10002000
                                0x4400          0x4000000       0x0             0x0
                                0x200000b3      0x40b6c3c3      0x26000000      0x41c42600
                                0x41c4          0x26000000      0xc0c52600      0x0
                                0x0             0x0             0x0             0x0
                                0x0             0x0             0x0             0x0
                                0x0             0x0             0x0             0x0
                                0x0             0x0             0x0             0x0
                                0x0             0x0             0x0             0xc6c6
                                0xc3c3c2c1      0xc300c3        0x818181        0x83c1c182
                                0x83838382      0x0             0x0             0x0
                                0x0             0x0             0x0             0x0
                                0x84002e00      0x90000087      0x8a000000      0x0
                                0x0             0x0             0x0             0x0
                                0x0             0x0             0x0             0x0
                                0xb000009       0x0             0x0             0x0
                                0x0             0x0             0x0             0x0
                                0x0             0x0             0x0             0x0
                                0x0             0x0             0x0             0x7707>;

        status = "okay";
};
```