### PR TITLE
MT76x0: Correct VHT MCS 8/9 tx power eeprom offset

### DIFF
--- a/mt76x0/eeprom.c
+++ b/mt76x0/eeprom.c
@@ -201,7 +201,7 @@ void mt76x0_get_tx_power_per_rate(struct mt76x02_dev *dev,
 	t->stbc[6] = t->stbc[7] = s6_to_s8(val >> 8);
 
 	/* vht mcs 8, 9 5GHz */
-	val = mt76x02_eeprom_get(dev, 0x132);
+	val = mt76x02_eeprom_get(dev, 0x12C);
 	t->vht[8] = s6_to_s8(val);
 	t->vht[9] = s6_to_s8(val >> 8);
 


### PR DESCRIPTION
Appears to have incorrectly offset 0x120 + 0x12 instead of 12 decimal, leading to bogus power values being used.

Signed-off-by: Richard Huynh <voxlympha@gmail.com>