### PR TITLE
mt76: mt7603: check SMPS enabled status before calling mt7603_wtbl1_addr

### DIFF
--- a/mt7603/mac.c
+++ b/mt7603/mac.c
@@ -214,10 +214,13 @@ void mt7603_filter_tx(struct mt7603_dev *dev, int idx, bool abort)
 void mt7603_wtbl_set_smps(struct mt7603_dev *dev, struct mt7603_sta *sta,
 			  bool enabled)
 {
-	u32 addr = mt7603_wtbl1_addr(sta->wcid.idx);
+	int idx = sta->wcid.idx;
+	u32 addr;
 
 	if (sta->smps == enabled)
 		return;
+
+	addr = mt7603_wtbl1_addr(idx);
 
 	mt76_rmw_field(dev, addr + 2 * 4, MT_WTBL1_W2_SMPS, enabled);
 	sta->smps = enabled;


### PR DESCRIPTION
Let mt7603_wtbl_set_smps return earlier if sta->smps == enabled.

Signed-off-by: Fushan Wen <qydwhotmail@gmail.com>