### PR TITLE
mt76: mt7603: disable SMPS intentionally to improve stability

### DIFF
--- a/mt7603/main.c
+++ b/mt7603/main.c
@@ -632,8 +632,7 @@ mt7603_sta_rate_tbl_update(struct ieee80211_hw *hw, struct ieee80211_vif *vif,
 	msta->n_rates = i;
 	mt7603_wtbl_set_rates(dev, msta, NULL, msta->rates);
 	msta->rate_probe = false;
-	mt7603_wtbl_set_smps(dev, msta,
-			     sta->smps_mode == IEEE80211_SMPS_DYNAMIC);
+	mt7603_wtbl_set_smps(dev, msta, 1 == 0);
 	spin_unlock_bh(&dev->mt76.lock);
 }
 


### PR DESCRIPTION
mt7603e does not handle SMPS well, making 2.4GHz AP disappear, system crash or connection unstable or lost. As long as 2.4G is mostly for smart home devices, it's worth disabling SMPS to get a stable AP.

Fixes #576
Reopens #26,  #145, #235

Signed-off-by: Fushan Wen <qydwhotmail@gmail.com>