### PR TITLE
mt76: mt7615: do not override extended phy mac from eeprom

### DIFF
--- a/mt7615/init.c
+++ b/mt7615/init.c
@@ -486,7 +486,6 @@ int mt7615_register_ext_phy(struct mt7615_dev *dev)
 	       ETH_ALEN);
 	mphy->macaddr[0] |= 2;
 	mphy->macaddr[0] ^= BIT(7);
-	mt76_eeprom_override(mphy);
 
 	/* second phy can only handle 5 GHz */
 	mphy->cap.has_5ghz = true;


### PR DESCRIPTION
It makes no sense changing mac for extended phy to the one
that differs from original phy's mac and instantly override
it from eeprom.

Signed-off-by: Markov Mikhail <markov.mikhail@itmh.ru>