### PR TITLE
MT76x0: Correct s6_to_s8 function

### DIFF
--- a/mt76x0/eeprom.h
+++ b/mt76x0/eeprom.h
@@ -27,7 +27,7 @@ static inline s8 s6_to_s8(u32 val)
 {
 	s8 ret = val & GENMASK(6, 0);
 
-	if (ret & BIT(6))
+	if (ret & BIT(5))
 		ret -= BIT(6);
 	return ret;
 }

--- a/mt76x0/eeprom.h
+++ b/mt76x0/eeprom.h
@@ -25,9 +25,9 @@ void mt76x0_get_power_info(struct mt76x02_dev *dev,
 
 static inline s8 s6_to_s8(u32 val)
 {
-	s8 ret = val & GENMASK(5, 0);
+	s8 ret = val & GENMASK(6, 0);
 
-	if (ret & BIT(5))
+	if (ret & BIT(6))
 		ret -= BIT(6);
 	return ret;
 }


### PR DESCRIPTION
MT76x0: Fix sign calculation for negative numbers in s6_to_s8 function