### PR TITLE
mt76: mt76u: consume_skb in all paths in __mt76x02u_mcu_send_msg

### DIFF
--- a/mt76x02_usb_mcu.c
+++ b/mt76x02_usb_mcu.c
@@ -103,12 +103,12 @@ __mt76x02u_mcu_send_msg(struct mt76_dev *dev, struct sk_buff *skb,
 	       MT_MCU_MSG_TYPE_CMD;
 	ret = mt76x02u_skb_dma_info(skb, CPU_TX_PORT, info);
 	if (ret)
-		return ret;
+		goto out;
 
 	ret = mt76u_bulk_msg(dev, skb->data, skb->len, NULL, 500,
 			     MT_EP_OUT_INBAND_CMD);
 	if (ret)
-		return ret;
+		goto out;
 
 	if (wait_resp)
 		ret = mt76x02u_mcu_wait_resp(dev, seq);


### PR DESCRIPTION
__mt76x02u_mcu_send_msg leaks the skb if mt76x02u_skb_dma_info or
mt76u_bulk_msg fails. This patch calls consume_skb on that paths too.

Signed-off-by: Gergo Koteles <soyer@irl.hu>