### PR TITLE
[Testers needed] mt76: mt7603: report firmware log messages

### DIFF
--- a/mt7603/debugfs.c
+++ b/mt7603/debugfs.c
@@ -93,6 +93,33 @@ mt7603_ampdu_stat_show(struct seq_file *file, void *data)
 
 DEFINE_SHOW_ATTRIBUTE(mt7603_ampdu_stat);
 
+static int
+mt7603_fw_debug_set(void *data, u64 val)
+{
+	struct mt7603_dev *dev = data;
+
+	dev->fw_debug = val;
+
+	mutex_lock(&dev->mt76.mutex);
+	mt7603_mcu_fw_log_2_host(dev, dev->fw_debug ? 2 : 0);
+	mutex_unlock(&dev->mt76.mutex);
+
+	return 0;
+}
+
+static int
+mt7603_fw_debug_get(void *data, u64 *val)
+{
+	struct mt7603_dev *dev = data;
+
+	*val = dev->fw_debug;
+
+	return 0;
+}
+
+DEFINE_DEBUGFS_ATTRIBUTE(fops_fw_debug, mt7603_fw_debug_get,
+			 mt7603_fw_debug_set, "%lld\n");
+
 void mt7603_init_debugfs(struct mt7603_dev *dev)
 {
 	struct dentry *dir;
@@ -115,4 +142,5 @@ void mt7603_init_debugfs(struct mt7603_dev *dev)
 			    &dev->sensitivity_limit);
 	debugfs_create_bool("dynamic_sensitivity", 0600, dir,
 			    &dev->dynamic_sensitivity);
+	debugfs_create_file("fw_debug", 0600, dir, dev, &fops_fw_debug);
 }

--- a/mt7603/dma.c
+++ b/mt7603/dma.c
@@ -2,6 +2,7 @@
 
 #include "mt7603.h"
 #include "mac.h"
+#include "mcu.h"
 #include "../dma.h"
 
 static void
@@ -93,7 +94,7 @@ void mt7603_queue_rx_skb(struct mt76_dev *mdev, enum mt76_rxq_id q,
 		dev_kfree_skb(skb);
 		break;
 	case PKT_TYPE_RX_EVENT:
-		mt76_mcu_rx_event(&dev->mt76, skb);
+		mt7603_mcu_rx_event(dev, skb);
 		return;
 	case PKT_TYPE_NORMAL:
 		if (mt7603_mac_fill_rx(dev, skb) == 0) {

--- a/mt7603/mt7603.h
+++ b/mt7603/mt7603.h
@@ -159,6 +159,8 @@ struct mt7603_dev {
 	u32 reset_test;
 
 	unsigned int reset_cause[__RESET_CAUSE_MAX];
+
+	bool fw_debug;
 };
 
 extern const struct mt76_driver_ops mt7603_drv_ops;
@@ -188,6 +190,8 @@ void mt7603_unregister_device(struct mt7603_dev *dev);
 int mt7603_eeprom_init(struct mt7603_dev *dev);
 int mt7603_dma_init(struct mt7603_dev *dev);
 void mt7603_dma_cleanup(struct mt7603_dev *dev);
+void mt7603_mcu_rx_event(struct mt7603_dev *dev, struct sk_buff *skb);
+int mt7603_mcu_fw_log_2_host(struct mt7603_dev *dev, u8 ctrl);
 int mt7603_mcu_init(struct mt7603_dev *dev);
 void mt7603_init_debugfs(struct mt7603_dev *dev);
 


### PR DESCRIPTION
Hi!

Since few weeks I've noticed some problems with my Wi-Fi connection on TV which uses 2.4G band. TV reports that it doesn't have connection to the Internet but I can ping TV's IP from Access Point. I wanted to check whether it's a firmware issue. That's why I've implemented a mechanism which enables forwarding messages from firmware in mt7603 (based on coolsnowwolf/lede repository).

Unfortunately I haven't seen any messages shown in the kernel's dmesg. That's why I'm asking for testing - maybe some has a faulty firmware or an idea how to modify driver's code to trigger firmware to log some messages.

If someone confirms that code in this commit logs properly messages from the firmware I'll send this to the wireless mailing list.

Thanks in advance!