### PR TITLE
MT7603: Fix EEPROM offset size in mt7603.h

### DIFF
--- a/mt7603/mt7603.h
+++ b/mt7603/mt7603.h
@@ -25,7 +25,7 @@
 #define MT7628_FIRMWARE_E1	"mt7628_e1.bin"
 #define MT7628_FIRMWARE_E2	"mt7628_e2.bin"
 
-#define MT7603_EEPROM_SIZE	1024
+#define MT7603_EEPROM_SIZE	512
 
 #define MT_AGG_SIZE_LIMIT(_n)	(((_n) + 1) * 4)
 


### PR DESCRIPTION
According the MT7603's GPL code, the correct EEPROM size is 0x200 (512 bytes). In mt76 drivers, the eeprom size is 0x400 (1024 bytes). Let's correct this.

Signed-off-by: Rodrigo B. de Sousa Martins <rodrigo.sousa.577@gmail.com>