### PR TITLE
mt7915: add CONFIG_MT76_LEDS to cflags

### DIFF
--- a/mt7915/Makefile
+++ b/mt7915/Makefile
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: ISC
 
+EXTRA_CFLAGS += -DCONFIG_MT76_LEDS
 obj-$(CONFIG_MT7915E) += mt7915e.o
 
 mt7915e-y := pci.o init.o dma.o eeprom.o main.o mcu.o mac.o \


### PR DESCRIPTION
As we have for mt7615.

Fixes: https://github.com/openwrt/mt76/issues/705

Signed-off-by: Marian Sarcinschi <znevna@gmail.com>