### PR TITLE
tools: Fix compile error with glibc

### DIFF
--- a/tools/eeprom.c
+++ b/tools/eeprom.c
@@ -209,6 +209,7 @@ static int
 mt76_eeprom_changes(void)
 {
 	unsigned char *buf;
+	size_t ret;
 	FILE *f;
 	int i;
 
@@ -220,7 +221,9 @@ mt76_eeprom_changes(void)
 
 	buf = malloc(EEPROM_PART_SIZE);
 	fseek(f, mtd_offset, SEEK_SET);
-	fread(buf, 1, EEPROM_PART_SIZE, f);
+	ret = fread(buf, 1, EEPROM_PART_SIZE, f);
+	if (ret != EEPROM_PART_SIZE)
+		return EXIT_FAILURE;
 	for (i = 0; i < EEPROM_PART_SIZE; i++) {
 		if (buf[i] == eeprom_data[i])
 			continue;


### PR DESCRIPTION
This fixes the following compile error when compiling against recent glibc:
````
/tools/eeprom.c:223:9: error: ignoring return value of 'fread' declared with attribute 'warn_unused_result' [-Werror=unused-result]
  223 |         fread(buf, 1, EEPROM_PART_SIZE, f);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
````

Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>