### PR TITLE
wifi: mt76: mt7915: re-enable VHT EXT NSS BW support

### DIFF
--- a/mt7915/init.c
+++ b/mt7915/init.c
@@ -384,6 +384,7 @@ mt7915_init_wiphy(struct mt7915_phy *phy)
 	ieee80211_hw_set(hw, SUPPORTS_RX_DECAP_OFFLOAD);
 	ieee80211_hw_set(hw, SUPPORTS_MULTI_BSSID);
 	ieee80211_hw_set(hw, WANT_MONITOR_VIF);
+	ieee80211_hw_set(hw, SUPPORTS_VHT_EXT_NSS_BW);
 
 	hw->max_tx_fragments = 4;
 


### PR DESCRIPTION
Fixes broken 80 Mhz channels on Redmi AX6000, etc. 

This option is required by some hardware, see: https://lore.kernel.org/all/c67b0bd143835dcb97aa1e642bdcdb2f78660c6c.1654576533.git.deren.wu@mediatek.com/ 

Partially reverts https://patchwork.kernel.org/project/linux-wireless/patch/20230301163739.52314-1-nbd@nbd.name/

Forum thread: https://forum.openwrt.org/t/802-11ax-worse-than-802-11ac-with-mt76-driver/126466/369

Needs testing.