### PR TITLE
wifi: mt76: mt7915: don't set NETIF_F_HW_TC on devices without RX WED

### DIFF
--- a/mt7915/init.c
+++ b/mt7915/init.c
@@ -346,7 +346,8 @@ mt7915_init_wiphy(struct mt7915_phy *phy)
 	hw->max_tx_aggregation_subframes = IEEE80211_MAX_AMPDU_BUF_HE;
 	hw->netdev_features = NETIF_F_RXCSUM;
 
-	if (mtk_wed_device_active(&mdev->mmio.wed))
+	if (mtk_wed_device_active(&mdev->mmio.wed) &&
+	    mtk_wed_get_rx_capa(&mdev->mmio.wed))
 		hw->netdev_features |= NETIF_F_HW_TC;
 
 	hw->radiotap_timestamp.units_pos =


### PR DESCRIPTION
Commit 56f0cd4d5e broke Ethernet to wireless offloading on NETSYS V1 devices (ie. MT7622+MT7915E). Only announce NETIF_F_HW_TC on devices capable of wireless to Ethernet or wireless to wireless offloading.

Fixes: 56f0cd4d5e ("wifi: mt76: mt7915 add tc offloading support")