### PR TITLE
wifi: mt76: add ability to explicitly forbid LED registration with DT

### DIFF
--- a/mac80211.c
+++ b/mac80211.c
@@ -198,10 +198,33 @@ static int mt76_led_init(struct mt76_phy *phy)
 {
 	struct mt76_dev *dev = phy->dev;
 	struct ieee80211_hw *hw = phy->hw;
+	struct device_node *np = dev->dev->of_node;
 
 	if (!phy->leds.cdev.brightness_set && !phy->leds.cdev.blink_set)
 		return 0;
+	
+	np = of_get_child_by_name(np, "led");
+	if (np) {
+		if (!of_device_is_available(np)) {
+			of_node_put(np);
+			dev_info(dev->dev,
+				"led registration was explicitly forbidden by device tree\n");
+			return 0;
+		}
 
+		if (phy == &dev->phy) {
+			int led_pin;
+
+			if (!of_property_read_u32(np, "led-sources", &led_pin))
+				phy->leds.pin = led_pin;
+
+			phy->leds.al = 
+				of_property_read_bool(np, "led-active-low");
+		}
+
+		of_node_put(np);
+	}
+	
 	snprintf(phy->leds.name, sizeof(phy->leds.name), "mt76-%s",
 		 wiphy_name(hw->wiphy));
 
@@ -212,20 +235,8 @@ static int mt76_led_init(struct mt76_phy *phy)
 					mt76_tpt_blink,
 					ARRAY_SIZE(mt76_tpt_blink));
 
-	if (phy == &dev->phy) {
-		struct device_node *np = dev->dev->of_node;
-
-		np = of_get_child_by_name(np, "led");
-		if (np) {
-			int led_pin;
-
-			if (!of_property_read_u32(np, "led-sources", &led_pin))
-				phy->leds.pin = led_pin;
-			phy->leds.al = of_property_read_bool(np,
-							     "led-active-low");
-			of_node_put(np);
-		}
-	}
+	dev_info(dev->dev,
+		"registering led '%s'\n", phy->leds.name);
 
 	return led_classdev_register(dev->dev, &phy->leds.cdev);
 }


### PR DESCRIPTION
Add ability to explicitly forbid mt76 to register LED device via Device Tree by setting `led { status = "disabled"; };`.

Example part of Device Tree configuration:

```
wifi@0,0 {
        compatible = "mediatek,mt76";
        // ...
        led {
            status = "disabled";
        };
};
```

<hr />

* `dev_info` message added for led registration.
  * Example: `[   11.504620] mt7603e 0000:01:00.0: registering led 'mt76-phy0'`
* `dev_info` message added when led registration is forbidden explicitly.
  * Example: `[   11.034916] mt7603e 0000:01:00.0: led registration was explicitly forbidden by device tree`
* Older code, where `mt76_led_init(...)` does not respect `led\status`, works normally when `led\status` is defined, but does not respect value - so it is safe to patch DT before this change will apply.
* Behavior stays the same when:
  * `led` node is not defined,
  * `led` node is defined, but no `status` option is defined,
  * `led` node is defined, and `status` option is defined with _okay-ish_ value, as implemented in `of_device_is_available(...)`,
* Behavior changes when:
  * `led` node is defined, and `status` option is defined with _not-okay-ish_ value, as implemented in `of_device_is_available(...)`,

<hr />

Tested on OpenWrt, ramips, comfast, cf-ew72-v2.

LED is registered as `/sys/class/leds/mt76-phy?` when `led` node:
* is not defined
* is defined empty
* is defined with `status = "okay"` or `status = "ok"`

```
root@OpenWrt:/# dmesg | grep mt7 | grep 'led\s'
[   11.025047] mt7603e 0000:01:00.0: registering led 'mt76-phy0'
[   11.084022] mt7615e 0000:02:00.0: registering led 'mt76-phy1'

root@OpenWrt:/# find /sys/class/leds/*
/sys/class/leds/blue:hidden_led_2
/sys/class/leds/blue:hidden_led_4
/sys/class/leds/blue:wlan
/sys/class/leds/mt76-phy0
/sys/class/leds/mt76-phy1
```

LED is __not__ registered as `/sys/class/leds/mt76-phy?` when `led` node:

* is defined with status not "ok" neither "okay"

```
root@OpenWrt:/# dmesg | grep mt7 | grep 'led\s'
[   11.034916] mt7603e 0000:01:00.0: led registration was explicitly forbidden by device tree
[   11.108691] mt7615e 0000:02:00.0: led registration was explicitly forbidden by device tree

root@OpenWrt:/# find /sys/class/leds/*
/sys/class/leds/blue:hidden_led_2
/sys/class/leds/blue:hidden_led_4
/sys/class/leds/blue:wlan
```

Closes feature request #810 .
