### PR TITLE
mt76: mt7915: make second phy mac unique when overridden

### DIFF
--- a/mt7915/init.c
+++ b/mt7915/init.c
@@ -661,16 +661,18 @@ mt7915_register_ext_phy(struct mt7915_dev *dev, struct mt7915_phy *phy)
 
 	memcpy(mphy->macaddr, dev->mt76.eeprom.data + MT_EE_MAC_ADDR2,
 	       ETH_ALEN);
+	if (!is_valid_ether_addr(mphy->macaddr))
+		memcpy(mphy->macaddr, dev->mt76.eeprom.data + MT_EE_MAC_ADDR,
+		       ETH_ALEN);
+	mt76_eeprom_override(mphy);
+
 	/* Make the secondary PHY MAC address local without overlapping with
 	 * the usual MAC address allocation scheme on multiple virtual interfaces
 	 */
-	if (!is_valid_ether_addr(mphy->macaddr)) {
-		memcpy(mphy->macaddr, dev->mt76.eeprom.data + MT_EE_MAC_ADDR,
-		       ETH_ALEN);
+	if (ether_addr_equal(mphy->macaddr, dev->mt76.phy.macaddr)) {
 		mphy->macaddr[0] |= 2;
 		mphy->macaddr[0] ^= BIT(7);
 	}
-	mt76_eeprom_override(mphy);
 
 	/* init wiphy according to mphy and phy */
 	mt7915_init_wiphy(phy);


### PR DESCRIPTION
The phys share a device tree node, so mt76_eeprom_override() will always load the exact same address for both.

Fix by moving the local address modification outside the eeprom fallback block, making it conditional on actual address conflicts. This will also catch any buggy eeprom with the same valid address in both fields.