### PR TITLE
linux-firmware changed: move FW to correct path

### DIFF
--- a/mt76x2/mt76x2.h
+++ b/mt76x2/mt76x2.h
@@ -16,8 +16,8 @@
 #include <linux/mutex.h>
 #include <linux/bitops.h>
 
-#define MT7662_FIRMWARE		"mt7662.bin"
-#define MT7662_ROM_PATCH	"mt7662_rom_patch.bin"
+#define MT7662_FIRMWARE		"mediatek/mt7662.bin"
+#define MT7662_ROM_PATCH	"mediatek/mt7662_rom_patch.bin"
 #define MT7662_EEPROM_SIZE	512
 
 #include "../mt76x02.h"


### PR DESCRIPTION
firmware path has changed, due to cleanup in linux-firmware git.

https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/commit/?id=8451c2b1d529dc1a49328ac9235d3cf5bb8a8fcb