### PR TITLE
wifi: mt76: mt7996: fix shift overflow warning on 32 bit systems

### DIFF
--- a/mt7996/mac.c
+++ b/mt7996/mac.c
@@ -942,9 +942,13 @@ int mt7996_tx_prepare_skb(struct mt76_dev *mdev, void *txwi_ptr,
 
 	txp = (struct mt76_connac_txp_common *)(txwi + MT_TXD_SIZE);
 	for (i = 0; i < nbuf; i++) {
-		u16 len = FIELD_PREP(MT_TXP_BUF_LEN, tx_info->buf[i + 1].len) |
-			  FIELD_PREP(MT_TXP_DMA_ADDR_H,
-				     tx_info->buf[i + 1].addr >> 32);
+		u16 len;
+
+		len = FIELD_PREP(MT_TXP_BUF_LEN, tx_info->buf[i + 1].len);
+#ifdef CONFIG_ARCH_DMA_ADDR_T_64BIT
+		len |= FIELD_PREP(MT_TXP_DMA_ADDR_H,
+				  tx_info->buf[i + 1].addr >> 32);
+#endif
 
 		txp->fw.buf[i] = cpu_to_le32(tx_info->buf[i + 1].addr);
 		txp->fw.len[i] = cpu_to_le16(len);


### PR DESCRIPTION
Fix additional shift overflow warning on 32 bit systems for mt7996 mac.c source.

Fixes: 95c14207d2a9 ("wifi: mt76: mt7996: set DMA mask to 36 bits for boards with more than 4GB of RAM")

---

@nbd168 think you missed this in the other commit fixing overflow warning. This was reported by openwrt CI on malta/be run