### PR TITLE
wifi: added USB_DEVICE for DStv Wi-Fi Connector MT7612U

### DIFF
--- a/mt76x2/usb.c
+++ b/mt76x2/usb.c
@@ -22,6 +22,7 @@ static const struct usb_device_id mt76x2u_device_table[] = {
 	{ USB_DEVICE(0x0846, 0x9053) },	/* Netgear A6210 */
 	{ USB_DEVICE(0x045e, 0x02e6) },	/* XBox One Wireless Adapter */
 	{ USB_DEVICE(0x045e, 0x02fe) },	/* XBox One Wireless Adapter */
+	{ USB_DEVICE(0x0bf0, 0xf006) },	/* DStv Wi-Fi Connector MT7612U */
 	{ },
 };
 


### PR DESCRIPTION
https://mybroadband.co.za/news/hardware/416126-we-stripped-a-dstv-wi-fi-connector-with-a-pleasant-surprise.html