### PR TITLE
wifi: mt76: fix kernel 6.7 compatibility

### DIFF
--- a/mac80211.c
+++ b/mac80211.c
@@ -613,7 +613,11 @@ int mt76_create_page_pool(struct mt76_dev *dev, struct mt76_queue *q)
 {
 	struct page_pool_params pp_params = {
 		.order = 0,
+#if LINUX_VERSION_IS_LESS(6,7,0)
 		.flags = PP_FLAG_PAGE_FRAG,
+#else
+		.flags = 0,
+#endif
 		.nid = NUMA_NO_NODE,
 		.dev = dev->dma_dev,
 	};


### PR DESCRIPTION
The PP_FLAG_PAGE_FRAG constant was removed in kernel 6.7, so we are removing it from code for kernels 6.7 and above.