### PR TITLE
Add tx_power check during eeprom loading

### DIFF
--- a/mt7996/eeprom.c
+++ b/mt7996/eeprom.c
@@ -206,6 +206,13 @@ static int mt7996_eeprom_load(struct mt7996_dev *dev)
 				goto out;
 			}
 		}
+
+		/* read tx_power values from fw */
+		u8 *eeprom = dev->mt76.eeprom.data;
+		if (!eeprom[MT_EE_TX0_POWER_2G] || !eeprom[MT_EE_TX0_POWER_5G] || !eeprom[MT_EE_TX0_POWER_6G] ) {
+			use_default = true;
+			goto out;
+		}
 	}
 
 out:


### PR DESCRIPTION
Hello.
As pointed out in openwrt/openwrt/issues/17489 - some BPI-R4-BE14 cards come with a stock firmware with no tx_power values for 2.4G and 5G bands. Which basically prevents using the 2/5G band as it defaults to 6dBm.
This PR adds a basic check in `mt7996_eeprom_load` that reads the power value from the first channel group for each band. If any of them is zero, it falls back to loading the default firmware from the disk.
It was confirmed working on both affected and unaffected devices in the main issue.