### PR TITLE
mt76: compatibility for kernel 6.11 and above

### DIFF
--- a/mt7603/soc.c
+++ b/mt7603/soc.c
@@ -52,15 +52,21 @@ error:
 	return ret;
 }
 
+#if LINUX_VERSION_IS_LESS(6,11,0)
 static int
+#else
+static void
+#endif
 mt76_wmac_remove(struct platform_device *pdev)
 {
 	struct mt76_dev *mdev = platform_get_drvdata(pdev);
 	struct mt7603_dev *dev = container_of(mdev, struct mt7603_dev, mt76);
 
 	mt7603_unregister_device(dev);
+#if LINUX_VERSION_IS_LESS(6,11,0)
 
 	return 0;
+#endif
 }
 
 static const struct of_device_id of_wmac_match[] = {

--- a/mt7615/soc.c
+++ b/mt7615/soc.c
@@ -45,13 +45,19 @@ static int mt7622_wmac_probe(struct platform_device *pdev)
 	return mt7615_mmio_probe(&pdev->dev, mem_base, irq, mt7615e_reg_map);
 }
 
+#if LINUX_VERSION_IS_LESS(6,11,0)
 static int mt7622_wmac_remove(struct platform_device *pdev)
+#else
+static void mt7622_wmac_remove(struct platform_device *pdev)
+#endif
 {
 	struct mt7615_dev *dev = platform_get_drvdata(pdev);
 
 	mt7615_unregister_device(dev);
+#if LINUX_VERSION_IS_LESS(6,11,0)
 
 	return 0;
+#endif
 }
 
 static const struct of_device_id mt7622_wmac_of_match[] = {

--- a/mt7915/soc.c
+++ b/mt7915/soc.c
@@ -1283,13 +1283,19 @@ free_device:
 	return ret;
 }
 
+#if LINUX_VERSION_IS_LESS(6,11,0)
 static int mt798x_wmac_remove(struct platform_device *pdev)
+#else
+static void mt798x_wmac_remove(struct platform_device *pdev)
+#endif
 {
 	struct mt7915_dev *dev = platform_get_drvdata(pdev);
 
 	mt7915_unregister_device(dev);
+#if LINUX_VERSION_IS_LESS(6,11,0)
 
 	return 0;
+#endif
 }
 
 static const struct of_device_id mt798x_wmac_of_match[] = {


### PR DESCRIPTION
In kernel 6.11 the struct platform_driver is changed. So for compatibility with this kernel the .remove functions were changed.