### PR TITLE
wifi: mt76: add temperature readouts to debugfs

### DIFF
--- a/mt76x0/phy.c
+++ b/mt76x0/phy.c
@@ -1036,15 +1036,16 @@ static void mt76x0_phy_temp_sensor(struct mt76x02_dev *dev)
 
 	val = mt76_rr(dev, MT_BBP(CORE, 35));
 	val = (35 * (val - dev->cal.rx.temp_offset)) / 10 + 25;
+	dev->cal.temp = val;
 
 	if (abs(val - dev->cal.temp_vco) > 20) {
 		mt76x02_mcu_calibrate(dev, MCU_CAL_VCO,
 				      dev->mphy.chandef.chan->hw_value);
 		dev->cal.temp_vco = val;
 	}
-	if (abs(val - dev->cal.temp) > 30) {
+	if (abs(val - dev->cal.temp_phy) > 30) {
 		mt76x0_phy_calibrate(dev, false);
-		dev->cal.temp = val;
+		dev->cal.temp_phy = val;
 	}
 
 done:

--- a/mt76x02.h
+++ b/mt76x02.h
@@ -46,6 +46,7 @@ struct mt76x02_calibration {
 	s8 agc_lowest_gain;
 	s8 low_gain;
 
+	s8 temp_phy;
 	s8 temp_vco;
 	s8 temp;
 

--- a/mt76x02_debugfs.c
+++ b/mt76x02_debugfs.c
@@ -139,7 +139,11 @@ void mt76x02_init_debugfs(struct mt76x02_dev *dev)
 
 	debugfs_create_devm_seqfile(dev->mt76.dev, "xmit-queues", dir,
 				    mt76_queues_read);
+
+	debugfs_create_u8("phy_cal_temperature", 0400, dir, &dev->cal.temp_phy);
+	debugfs_create_u8("vco_cal_temperature", 0400, dir, &dev->cal.temp_vco);
 	debugfs_create_u8("temperature", 0400, dir, &dev->cal.temp);
+
 	debugfs_create_bool("tpc", 0600, dir, &dev->enable_tpc);
 
 	debugfs_create_file("edcca", 0600, dir, dev, &fops_edcca);


### PR DESCRIPTION
This makes makes it possible to read the last actual temperature sensor readout, and temperatures at last VCO and PHY calibations from separate files in debugfs.

Previously "mt76/temperature" in debugfs only showed last PHY calibration temperature, not last readout, which was confusing.

I'm not sure what the units are supposed to be here. The arithmetic in the code looks suspiciously like conversion from Celsius to Fahrenheit. On a MT7610E (TP-Link Archer C20 v1) I get read outs of around 82-86 while an IR thermometer on the actual chip shows around 30 degrees Celsius, so it roughly makes sense that it's in degrees Fahrenheit.

In any case, the resolution of the readout isn't that great, only roughly 2 degrees Celsius/4 degrees Fahrenheit.