### PR TITLE
wifi: mt76: mt7921: don't disconnect when CSA to DFS chan

### DIFF
--- a/mt7921/main.c
+++ b/mt7921/main.c
@@ -1460,11 +1460,8 @@ static int mt7921_pre_channel_switch(struct ieee80211_hw *hw,
 	if (vif->type != NL80211_IFTYPE_STATION || !vif->cfg.assoc)
 		return -EOPNOTSUPP;
 
-	/* Avoid beacon loss due to the CAC(Channel Availability Check) time
-	 * of the AP.
-	 */
 	if (!cfg80211_chandef_usable(hw->wiphy, &chsw->chandef,
-				     IEEE80211_CHAN_RADAR))
+				     IEEE80211_CHAN_DISABLED))
 		return -EOPNOTSUPP;
 
 	return 0;


### PR DESCRIPTION
When station mode don't disconnect when we get
channel switch from AP to DFS channel. Most/all APs send CSA request after pass background CAC. In other case we should disconnect after detect beacon miss.

Without patch when we get CSA to DFS channel get:
"kernel: wlo1: preparing for channel switch failed, disconnecting"

Seems today only mt7921 in my laptop behave like this (disconnect each CSA to DFS channel). Don't see this when using Intel or Qualcomm wifi card in station mode.