### PR TITLE
mt7925e: fix buffer overflow in mt76_connac2_load_patch()

### DIFF
--- a/mt76_connac_mcu.c
+++ b/mt76_connac_mcu.c
@@ -3124,7 +3124,7 @@ int mt76_connac2_load_patch(struct mt76_dev *dev, const char *fw_name)
 	}
 
 	hdr = (const void *)fw->data;
-	dev_info(dev->dev, "HW/SW Version: 0x%x, Build Time: %.16s\n",
+	dev_info(dev->dev, "HW/SW Version: 0x%x, Build Time: %.15s\n",
 		 be32_to_cpu(hdr->hw_sw_ver), hdr->build_date);
 
 	for (i = 0; i < be32_to_cpu(hdr->desc.n_region); i++) {


### PR DESCRIPTION
Fix strnlen buffer overflow in `mt76_connac2_load_patch()` function when loading firmware for MediaTek MT7925 WiFi chipset on kernel 6.19.0-rc1.

The issue occurs at line 3128 where `dev_info()` uses format specifier `%.16s` on a 16-byte buffer (`mt76_connac2_patch_hdr.build_date[16]`). Without a guaranteed null-terminator within the buffer bounds, the fortified `strnlen` function detects a read beyond buffer boundaries.

## Error Message

```
strnlen: detected buffer overflow: 17 byte read of buffer size 16
kernel BUG at lib/string_helpers.c:1043!
Oops: invalid opcode: 0000 [#1] SMP NOPTI
```

## Root Cause

The format specifier `%.16s` specifies the maximum number of characters to read as 16, but the buffer `build_date[16]` only has 16 bytes total. If the string is not null-terminated within those 16 bytes, `strnlen` will attempt to read byte 17, causing buffer overflow detection on kernels with `_FORTIFY_SOURCE` enabled.

## Solution

Change the format specifier from `%.16s` to `%.15s`. This ensures we never read beyond the 16-byte buffer bounds.

This approach is consistent with the similar structure `mt76_connac2_fw_trailer` which has a 15-byte `build_date` field and uses `%.15s` format specifier in the `mt76_connac2_load_ram()` function (line 3051).

## Testing

- **Kernel:** 6.19.0-rc1-1-cachyos-rc
- **Device:** MediaTek MT7925
- **Regression:** From 6.18.2 (works fine)
- **Impact:** Kernel panic on boot → System boots successfully

## Files Changed

- `mt76_connac_mcu.c`: Line 3127, format specifier `%.16s` → `%.15s`

