### PR TITLE
wifi: mt76: mt7925: add MCU command error handling

### DIFF
--- a/mt7925/main.c
+++ b/mt7925/main.c
@@ -891,11 +891,14 @@ static int mt7925_mac_link_sta_add(struct mt76_dev *mdev,
 	/* should update bss info before STA add */
 	if (vif->type == NL80211_IFTYPE_STATION && !link_sta->sta->tdls) {
 		if (ieee80211_vif_is_mld(vif))
-			mt7925_mcu_add_bss_info(&dev->phy, mconf->mt76.ctx,
-						link_conf, link_sta, link_sta != mlink->pri_link);
+			ret = mt7925_mcu_add_bss_info(&dev->phy, mconf->mt76.ctx,
+						      link_conf, link_sta,
+						      link_sta != mlink->pri_link);
 		else
-			mt7925_mcu_add_bss_info(&dev->phy, mconf->mt76.ctx,
-						link_conf, link_sta, false);
+			ret = mt7925_mcu_add_bss_info(&dev->phy, mconf->mt76.ctx,
+						      link_conf, link_sta, false);
+		if (ret)
+			return ret;
 	}
 
 	if (ieee80211_vif_is_mld(vif) &&

--- a/mt7925/main.c
+++ b/mt7925/main.c
@@ -633,8 +633,10 @@ static int mt7925_set_link_key(struct ieee80211_hw *hw, enum set_key_cmd cmd,
 		struct mt792x_phy *phy = mt792x_hw_phy(hw);
 
 		mconf->mt76.cipher = mt7925_mcu_get_cipher(key->cipher);
-		mt7925_mcu_add_bss_info(phy, mconf->mt76.ctx, link_conf,
-					link_sta, true);
+		err = mt7925_mcu_add_bss_info(phy, mconf->mt76.ctx, link_conf,
+					      link_sta, true);
+		if (err)
+			goto out;
 	}
 
 	if (cmd == SET_KEY)

--- a/mt7925/main.c
+++ b/mt7925/main.c
@@ -1255,22 +1255,22 @@ mt7925_ampdu_action(struct ieee80211_hw *hw, struct ieee80211_vif *vif,
 	case IEEE80211_AMPDU_RX_START:
 		mt76_rx_aggr_start(&dev->mt76, &msta->deflink.wcid, tid, ssn,
 				   params->buf_size);
-		mt7925_mcu_uni_rx_ba(dev, params, true);
+		ret = mt7925_mcu_uni_rx_ba(dev, params, true);
 		break;
 	case IEEE80211_AMPDU_RX_STOP:
 		mt76_rx_aggr_stop(&dev->mt76, &msta->deflink.wcid, tid);
-		mt7925_mcu_uni_rx_ba(dev, params, false);
+		ret = mt7925_mcu_uni_rx_ba(dev, params, false);
 		break;
 	case IEEE80211_AMPDU_TX_OPERATIONAL:
 		mtxq->aggr = true;
 		mtxq->send_bar = false;
-		mt7925_mcu_uni_tx_ba(dev, params, true);
+		ret = mt7925_mcu_uni_tx_ba(dev, params, true);
 		break;
 	case IEEE80211_AMPDU_TX_STOP_FLUSH:
 	case IEEE80211_AMPDU_TX_STOP_FLUSH_CONT:
 		mtxq->aggr = false;
 		clear_bit(tid, &msta->deflink.wcid.ampdu_state);
-		mt7925_mcu_uni_tx_ba(dev, params, false);
+		ret = mt7925_mcu_uni_tx_ba(dev, params, false);
 		break;
 	case IEEE80211_AMPDU_TX_START:
 		set_bit(tid, &msta->deflink.wcid.ampdu_state);
@@ -1279,8 +1279,9 @@ mt7925_ampdu_action(struct ieee80211_hw *hw, struct ieee80211_vif *vif,
 	case IEEE80211_AMPDU_TX_STOP_CONT:
 		mtxq->aggr = false;
 		clear_bit(tid, &msta->deflink.wcid.ampdu_state);
-		mt7925_mcu_uni_tx_ba(dev, params, false);
-		ieee80211_stop_tx_ba_cb_irqsafe(vif, sta->addr, tid);
+		ret = mt7925_mcu_uni_tx_ba(dev, params, false);
+		if (!ret)
+			ieee80211_stop_tx_ba_cb_irqsafe(vif, sta->addr, tid);
 		break;
 	}
 	mt792x_mutex_release(dev);


### PR DESCRIPTION
This PR adds error handling for critical MCU commands in the MT7925 driver.

## Problem

Several MCU commands in the MT7925 driver ignore return values, which could leave
the driver and firmware in inconsistent states when commands fail.

## Changes

### Patch 1: AMPDU MCU Error Handling
- Check return values of `mt7925_mcu_uni_rx_ba()` and `mt7925_mcu_uni_tx_ba()`
- Propagate errors from block aggregation setup/teardown
- Only call completion callback if MCU command succeeded

### Patch 2: Station Add BSS Info Error Handling
- Check return value of `mt7925_mcu_add_bss_info()` in `mt7925_mac_link_sta_add()`
- Prevent station creation if BSS info setup fails
- Avoids inconsistent state where station exists without BSS config

### Patch 3: Key Setup BSS Info Error Handling
- Check return value of `mt7925_mcu_add_bss_info()` during cipher setup
- Ensure BSS cipher configuration succeeds before key programming
- Prevents keys being programmed for misconfigured BSS

## Testing

Tested on Framework Desktop (AMD Ryzen AI Max 300 Series) with MT7925 WiFi.
These fixes complement the mutex fixes in PR #1029 and NULL checks in PR #1030.

## Related

- Part of ongoing effort to fix MT7925 stability issues
- See: https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2137291