### PR TITLE
wifi: mt76: mt792x: fix NULL pointer dereference in TX path

### DIFF
--- a/mt792x_core.c
+++ b/mt792x_core.c
@@ -95,6 +95,8 @@ void mt792x_tx(struct ieee80211_hw *hw, struct ieee80211_tx_control *control,
 				       IEEE80211_TX_CTRL_MLO_LINK);
 		sta = (struct mt792x_sta *)control->sta->drv_priv;
 		mlink = mt792x_sta_to_link(sta, link_id);
+		if (!mlink)
+			goto free_skb;
 		wcid = &mlink->wcid;
 	}
 
@@ -113,9 +115,12 @@ void mt792x_tx(struct ieee80211_hw *hw, struct ieee80211_tx_control *control,
 		link_id = wcid->link_id;
 		rcu_read_lock();
 		conf = rcu_dereference(vif->link_conf[link_id]);
-		memcpy(hdr->addr2, conf->addr, ETH_ALEN);
-
 		link_sta = rcu_dereference(control->sta->link[link_id]);
+		if (!conf || !link_sta) {
+			rcu_read_unlock();
+			goto free_skb;
+		}
+		memcpy(hdr->addr2, conf->addr, ETH_ALEN);
 		memcpy(hdr->addr1, link_sta->addr, ETH_ALEN);
 
 		if (vif->type == NL80211_IFTYPE_STATION)
@@ -136,6 +141,10 @@ void mt792x_tx(struct ieee80211_hw *hw, struct ieee80211_tx_control *control,
 	}
 
 	mt76_connac_pm_queue_skb(hw, &dev->pm, wcid, skb);
+	return;
+
+free_skb:
+	ieee80211_free_txskb(hw, skb);
 }
 EXPORT_SYMBOL_GPL(mt792x_tx);
 


### PR DESCRIPTION
## CRITICAL FIX

This patch fixes a NULL pointer dereference bug in `mt792x_tx()` that can cause
kernel crashes when transmitting packets during MLO link removal.

**Affects both MT7921 and MT7925 drivers** since mt792x_core.c is shared.

## The Bug

```c
mlink = mt792x_sta_to_link(sta, link_id);
wcid = &mlink->wcid;  // <-- NULL dereference if mlink is NULL!
```

`mt792x_sta_to_link()` can return NULL during link removal, but there was no
check before dereferencing.

Also, RCU-dereferenced `conf` and `link_sta` pointers were used without
NULL validation.

## Race Condition

1. A packet is queued for transmission
2. Concurrently, the link is being removed (`mt7925_mac_link_sta_remove`)
3. `mt792x_sta_to_link()` returns NULL for the removed link
4. **Kernel crashes** on `wcid = &mlink->wcid` dereference

## Fix

- Check `mlink` return value before dereferencing `wcid`
- Check RCU-dereferenced `conf` and `link_sta` before use
- Free the SKB and return early if any pointer is NULL

## Testing

Tested on Framework Desktop (AMD Ryzen AI Max 300 Series) with MT7925 WiFi.

## Related PRs

- PR #1029: Critical mutex fixes
- PR #1030: NULL checks (MCU TLV, main.c)
- PR #1031: MCU error handling
- PR #1032: MLO link/chanctx NULL checks