### PR TITLE
wifi: mt76: mt7925: add lockdep assertions for mutex verification

### DIFF
--- a/mt7925/mcu.c
+++ b/mt7925/mcu.c
@@ -1527,6 +1527,8 @@ int mt7925_mcu_uni_bss_ps(struct mt792x_dev *dev,
 		},
 	};
 
+	lockdep_assert_held(&dev->mt76.mutex);
+
 	if (link_conf->vif->type != NL80211_IFTYPE_STATION)
 		return -EOPNOTSUPP;
 
@@ -2028,6 +2030,8 @@ int mt7925_mcu_sta_update(struct mt792x_dev *dev,
 	};
 	struct mt792x_sta *msta;
 	struct mt792x_link_sta *mlink;
+
+	lockdep_assert_held(&dev->mt76.mutex);
 
 	if (link_sta) {
 		msta = (struct mt792x_sta *)link_sta->sta->drv_priv;
@@ -2834,6 +2838,8 @@ int mt7925_mcu_add_bss_info(struct mt792x_phy *phy,
 	struct mt792x_dev *dev = phy->dev;
 	struct mt792x_link_sta *mlink_bc;
 	struct sk_buff *skb;
+
+	lockdep_assert_held(&dev->mt76.mutex);
 
 	skb = __mt7925_mcu_alloc_bss_req(&dev->mt76, &mconf->mt76,
 					 MT7925_BSS_UPDATE_MAX_SIZE);


### PR DESCRIPTION
Add lockdep_assert_held() calls to critical MCU functions to help catch mutex violations during development and debugging. This follows the pattern used in other mt76 drivers (mt7996, mt7915, mt7615).

## Functions with new assertions

- **mt7925_mcu_add_bss_info()**: Core BSS configuration MCU command
- **mt7925_mcu_sta_update()**: Station record update MCU command
- **mt7925_mcu_uni_bss_ps()**: Power save state MCU command

## Purpose

These functions modify firmware state and must be called with the device mutex held to prevent race conditions. The lockdep assertions will:

1. Help catch mutex violations during development with CONFIG_LOCKDEP=y
2. Document the locking requirements for these functions
3. Make debugging easier when new callers are added

## Background

This is a follow-up to my mutex protection patches (PRs #1029, #1030, #1031, #1032, #1033, #1034) and helps ensure the locking requirements are properly enforced.

Related PRs:
- #1027 (MT7925 mutex fixes)
- #1030-#1033 (MT7925 NULL checks and error handling)
- #1034 (MT7921 mutex fixes)

Signed-off-by: Zac Bowling <zac@zacbowling.com>