### PR TITLE
wifi: mt76: mt7925: fix kernel warning in MLO ROC setup

### DIFF
--- a/mt7925/mcu.c
+++ b/mt7925/mcu.c
@@ -1337,15 +1337,23 @@ int mt7925_mcu_set_mlo_roc(struct mt792x_bss_conf *mconf, u16 sel_links,
 	for (i = 0; i < ARRAY_SIZE(links); i++) {
 		links[i].id = i ? __ffs(~BIT(mconf->link_id) & sel_links) :
 				 mconf->link_id;
+
 		link_conf = mt792x_vif_to_bss_conf(vif, links[i].id);
-		if (WARN_ON_ONCE(!link_conf))
-			return -EPERM;
+		if (!link_conf)
+			return -ENOLINK;
 
 		links[i].chan = link_conf->chanreq.oper.chan;
-		if (WARN_ON_ONCE(!links[i].chan))
-			return -EPERM;
+		if (!links[i].chan)
+			/* Channel not configured yet - this can happen during
+			 * MLO AP setup when links are being added sequentially.
+			 * Return -ENOLINK to indicate link not ready.
+			 */
+			return -ENOLINK;
 
 		links[i].mconf = mt792x_vif_to_link(mvif, links[i].id);
+		if (!links[i].mconf)
+			return -ENOLINK;
+
 		links[i].tag = links[i].id == mconf->link_id ?
 			       UNI_ROC_ACQUIRE : UNI_ROC_SUB_LINK;
 
@@ -1359,8 +1367,8 @@ int mt7925_mcu_set_mlo_roc(struct mt792x_bss_conf *mconf, u16 sel_links,
 		type = MT7925_ROC_REQ_JOIN;
 
 	for (i = 0; i < ARRAY_SIZE(links) && i < hweight16(vif->active_links); i++) {
-		if (WARN_ON_ONCE(!links[i].mconf || !links[i].chan))
-			continue;
+		if (!links[i].mconf || !links[i].chan)
+			return -ENOLINK;
 
 		chan = links[i].chan;
 		center_ch = ieee80211_frequency_to_channel(chan->center_freq);


### PR DESCRIPTION
During MLO AP setup, `mt7925_mcu_set_mlo_roc()` can be called before all
links have their channels configured. The existing code uses `WARN_ON_ONCE()`
to check for NULL link_conf and channel pointers, which triggers kernel
warnings/oops that appear as crashes even though it's just a timing issue.

This patch:
1. Replaces `WARN_ON_ONCE()` with regular NULL checks
2. Returns `-ENOLINK` to indicate the link isn't fully configured
3. Adds an mconf NULL check in the first loop (previously only in second loop)

The `-ENOLINK` return allows upper layers to retry when the link is ready,
without spamming kernel logs with warnings.

**Fixes:** #1014 (kernel oops on MLO AP setup)

**Related:** This is part of a series fixing MLO stability issues in MT7925:
- PR #1029: NULL pointer and mutex fixes
- PR #1030, #1032: Additional NULL checks
- PR #1037: Key removal during MLO roaming

**Testing:** Addresses kernel oops reported on Radxa ROCK 5 ITX+ with OpenWrt.