### PR TITLE
wifi: mt76: mt7925: add NULL checks for MLO link operations

### DIFF
--- a/mt7925/main.c
+++ b/mt7925/main.c
@@ -856,12 +856,17 @@ static int mt7925_mac_link_sta_add(struct mt76_dev *mdev,
 
 	msta = (struct mt792x_sta *)link_sta->sta->drv_priv;
 	mlink = mt792x_sta_to_link(msta, link_id);
+	if (!mlink)
+		return -EINVAL;
 
 	idx = mt76_wcid_alloc(dev->mt76.wcid_mask, MT792x_WTBL_STA - 1);
 	if (idx < 0)
 		return -ENOSPC;
 
 	mconf = mt792x_vif_to_link(mvif, link_id);
+	if (!mconf)
+		return -EINVAL;
+
 	mt76_wcid_init(&mlink->wcid, 0);
 	mlink->wcid.sta = 1;
 	mlink->wcid.idx = idx;
@@ -1690,6 +1695,9 @@ mt7925_conf_tx(struct ieee80211_hw *hw, struct ieee80211_vif *vif,
 		    [IEEE80211_AC_BE] = 0,
 		    [IEEE80211_AC_BK] = 1,
 	};
+
+	if (!mconf)
+		return -EINVAL;
 
 	/* firmware uses access class index */
 	mconf->queue_params[mq_to_aci[queue]] = *params;


### PR DESCRIPTION
Add NULL pointer checks for mt792x_sta_to_link() and mt792x_vif_to_link() results in critical paths to prevent kernel crashes during MLO operations.

Functions fixed:
- mt7925_mac_link_sta_add() - Check mlink and mconf before use
- mt7925_conf_tx() - Check mconf before use

These NULL checks prevent kernel crashes from NULL pointer dereferences during MLO link state transitions, especially during roaming or link removal operations.

Found by static analysis review.