### PR TITLE
wifi: mt76: mt7925: add mutex protection in resume path

### DIFF
--- a/mt7925/pci.c
+++ b/mt7925/pci.c
@@ -582,10 +582,12 @@ static int _mt7925_pci_resume(struct device *device, bool restore)
 	}
 
 	/* restore previous ds setting */
+	mt792x_mutex_acquire(dev);
 	if (!pm->ds_enable)
 		mt7925_mcu_set_deep_sleep(dev, false);
 
 	mt7925_mcu_regd_update(dev, mdev->alpha2, dev->country_ie_env);
+	mt792x_mutex_release(dev);
 failed:
 	pm->suspended = false;
 


### PR DESCRIPTION
Add mutex protection around mt7925_mcu_set_deep_sleep() and mt7925_mcu_regd_update() calls in the resume path to prevent potential race conditions during resume operations.

These MCU operations require serialization, and the resume path was the only call site missing mutex protection.

Found by static analysis (sparse/coccinelle).

Fixes a race condition where MCU operations during resume could occur concurrently with other operations, potentially causing system instability.