### PR TITLE
wifi: mt76: use hrtimer_setup() in mt76x02u beacon init

### DIFF
--- a/mt76x02_usb_core.c
+++ b/mt76x02_usb_core.c
@@ -264,8 +264,8 @@ void mt76x02u_init_beacon_config(struct mt76x02_dev *dev)
 	};
 	dev->beacon_ops = &beacon_ops;
 
-	hrtimer_init(&dev->pre_tbtt_timer, CLOCK_MONOTONIC, HRTIMER_MODE_REL);
-	dev->pre_tbtt_timer.function = mt76x02u_pre_tbtt_interrupt;
+	hrtimer_setup(&dev->pre_tbtt_timer, mt76x02u_pre_tbtt_interrupt, CLOCK_MONOTONIC,
+		      HRTIMER_MODE_REL);
 	INIT_WORK(&dev->pre_tbtt_work, mt76x02u_pre_tbtt_work);
 
 	mt76x02_init_beacon_config(dev);


### PR DESCRIPTION
Replace the two-step hrtimer initialization pattern with a single consolidated call to hrtimer_setup().
The legacy approach of calling hrtimer_init() followed by manual assignment to timer.function is deprecated.
The new hrtimer_setup() helper atomically initializes the timer and assigns the callback function in one operation, 
eliminating the race-prone intermediate state where the timer is initialized but lacks a handler.
The patch allows for correct compilation on kernel 6.18.

Link: https://lore.kernel.org/all/71fbc442aee9a9e892e475f3bbf8f368c6692a55.1738746872.git.namcao@linutronix.de