### PR TITLE
mt7603: make PCI optional

### DIFF
--- a/mt7603/Makefile
+++ b/mt7603/Makefile
@@ -3,6 +3,8 @@ EXTRA_CFLAGS += -Werror -DCONFIG_MT76_LEDS
 obj-m += mt7603e.o
 
 mt7603e-y := \
-	pci.o soc.o main.o init.o mcu.o \
+	soc.o main.o init.o mcu.o \
 	core.o dma.o mac.o eeprom.o \
 	beacon.o debugfs.o
+
+mt7603e-$(CONFIG_PCI) += pci.o


### PR DESCRIPTION
Many devices on mt7628 platform have this interface on their SoC bus and do not need PCI at all