### PR TITLE
wifi: mt76: mt7996: guard tx_retries against TXFREE count=0

### DIFF
--- a/mt7996/mac.c
+++ b/mt7996/mac.c
@@ -1360,13 +1360,14 @@ next:
 				cur_info++;
 			continue;
 		} else if (info & MT_TXFREE_INFO_HEADER) {
-			u32 tx_retries = 0, tx_failed = 0;
+			u32 tx_retries = 0, tx_failed = 0, tx_count;
 
 			if (!wcid)
 				continue;
 
-			tx_retries =
-				FIELD_GET(MT_TXFREE_INFO_COUNT, info) - 1;
+			tx_count = FIELD_GET(MT_TXFREE_INFO_COUNT, info);
+			if (tx_count)
+				tx_retries = tx_count - 1;
 			tx_failed = tx_retries +
 				!!FIELD_GET(MT_TXFREE_INFO_STAT, info);
 


### PR DESCRIPTION
In mt7996_mac_tx_free(), tx_retries is calculated as
FIELD_GET(MT_TXFREE_INFO_COUNT, info) - 1. When count is 0 (which
happens with NPU/WED WiFi offload), this underflows to ~4 billion
and corrupts wcid->stats.tx_retries.

Fix by checking count before subtracting.

Seen on Airoha AN7581 with NPU WiFi offload active — iw station dump
shows bogus retry counts in the billions. Same issue would affect any
mt7996 device using WED offload where TXFREE entries arrive with
count=0.