### PR TITLE
wifi: mt76: mt792x: add firmware hang watchdog for USB AP mode

### DIFF
--- a/mt792x.h
+++ b/mt792x.h
@@ -174,6 +174,11 @@ struct mt792x_phy {
 	struct mt76_mib_stats mib;
 
 	u8 sta_work_count;
+
+	/* USB AP mode firmware hang watchdog */
+	u32 tx_watch_prev;
+	u8  tx_watch_count;
+
 	u8 clc_chan_conf;
 	enum mt792x_reg_power_type power_type;
 

--- a/mt792x_mac.c
+++ b/mt792x_mac.c
@@ -22,6 +22,34 @@ void mt792x_mac_work(struct work_struct *work)
 		mphy->mac_work_count = 0;
 
 		mt792x_mac_update_mib_stats(phy);
+
+		/* USB AP mode firmware hang watchdog.
+		 *
+		 * For USB, pm.enable=false and drv_own/fw_own are not
+		 * implemented, so the normal MCU-timeout self-healing path
+		 * does not exist. The firmware can hang completely — both
+		 * RX and TX dead, no beacons — without logging any error.
+		 *
+		 * tx_mpdu_attempts_cnt is read via mt76_rr() which maps to
+		 * USB vendor-control transfers, not bulk, so it is readable
+		 * even when the bulk endpoint is frozen. While any BSS is
+		 * active (omac_mask != 0) the firmware always generates
+		 * beacon frames, so this counter must advance. Four
+		 * consecutive frozen cycles (~2 s) means firmware hang.
+		 */
+		if (mt76_is_usb(&phy->dev->mt76) && phy->omac_mask) {
+			if (phy->mib.tx_mpdu_attempts_cnt == phy->tx_watch_prev) {
+				if (++phy->tx_watch_count >= 4) {
+					phy->tx_watch_count = 0;
+					dev_warn(phy->dev->mt76.dev,
+						 "mt7921u: TX frozen, triggering chip reset\n");
+					mt792x_reset(&phy->dev->mt76);
+				}
+			} else {
+				phy->tx_watch_count = 0;
+			}
+			phy->tx_watch_prev = phy->mib.tx_mpdu_attempts_cnt;
+		}
 	}
 
 	mt792x_mutex_release(phy->dev);


### PR DESCRIPTION
For USB devices, pm.enable is false and drv_own/fw_own are not implemented
in hif_ops, so the normal self-healing path — where a timed-out MCU command
triggers mt792x_reset() — does not exist. mt76_connac_pm_wake() and
mt76_connac_power_save_sched() both return immediately for USB, so no
periodic MCU commands are ever sent after AP setup. The firmware can hang
completely (RX dead, TX dead, no beacons) without the driver observing any
error or logging anything.

Add a watchdog in mt792x_mac_work() that detects this condition.
mib.tx_mpdu_attempts_cnt is read via mt76_rr(), which for USB maps to a
vendor-control transfer rather than a bulk transfer, so it remains readable
even when the bulk endpoint is frozen. While any BSS is active
(omac_mask != 0), the firmware continuously transmits beacon frames and this
counter must advance. Four consecutive 500 ms cycles with no change (~2 s
total) indicates a firmware hang, and triggers chip reset.

This was observed on MT7921U in AP mode: all associated stations drop
simultaneously with "disassociated due to inactivity" as their 300 s
inactivity timers expire, the SSID disappears from scans, and RX byte
counters freeze in /proc/net/dev — with no kernel or hostapd errors. The
hang is reproducible under sustained high throughput.