### PR TITLE
[DRAFT] wifi: mt76: mt7925: MT7927 txpower and scan retry fixes

### DIFF
--- a/mt7925/init.c
+++ b/mt7925/init.c
@@ -223,6 +223,7 @@ int mt7925_register_device(struct mt792x_dev *dev)
 	spin_lock_init(&dev->pm.txq_lock);
 	INIT_DELAYED_WORK(&dev->mphy.mac_work, mt792x_mac_work);
 	INIT_DELAYED_WORK(&dev->phy.scan_work, mt7925_scan_work);
+	INIT_DELAYED_WORK(&dev->phy.scan_retry_work, mt7925_scan_retry_work);
 	INIT_DELAYED_WORK(&dev->coredump.work, mt7925_coredump_work);
 #if IS_ENABLED(CONFIG_IPV6)
 	INIT_WORK(&dev->ipv6_ns_work, mt7925_set_ipv6_ns_work);

--- a/mt7925/main.c
+++ b/mt7925/main.c
@@ -12,6 +12,9 @@
 #include "mcu.h"
 #include "mac.h"
 
+#define MT7925_SCAN_RETRY_MAX		3
+#define MT7925_SCAN_RETRY_MS		1500
+
 static void
 mt7925_init_he_caps(struct mt792x_phy *phy, enum nl80211_band band,
 		    struct ieee80211_sband_iftype_data *data,
@@ -1475,6 +1478,55 @@ void mt7925_mlo_pm_work(struct work_struct *work)
 					    mt7925_mlo_pm_iter, dev);
 }
 
+void mt7925_abort_scan(struct mt792x_phy *phy)
+{
+	struct cfg80211_scan_info info = {
+		.aborted = true,
+	};
+	bool scanning;
+
+	scanning = test_and_clear_bit(MT76_HW_SCANNING, &phy->mt76->state);
+	if (!phy->scan_req && !scanning)
+		return;
+
+	phy->scan_req = NULL;
+	phy->scan_vif = NULL;
+	phy->scan_2ghz = false;
+	phy->scan_zero_complete_retries = 0;
+	ieee80211_scan_completed(phy->mt76->hw, &info);
+}
+
+void mt7925_scan_retry_work(struct work_struct *work)
+{
+	struct mt792x_phy *phy;
+	struct mt792x_dev *dev;
+	int err;
+
+	phy = container_of(work, struct mt792x_phy, scan_retry_work.work);
+	dev = phy->dev;
+
+	if (!phy->scan_req || !phy->scan_vif)
+		return;
+
+	mt792x_mutex_acquire(dev);
+	if (!phy->scan_req || !phy->scan_vif) {
+		mt792x_mutex_release(dev);
+		return;
+	}
+
+	if (dev->pm.suspended) {
+		mt7925_abort_scan(phy);
+		mt792x_mutex_release(dev);
+		return;
+	}
+
+	err = mt7925_mcu_hw_scan(phy->mt76, phy->scan_vif, phy->scan_req);
+	if (err)
+		mt7925_abort_scan(phy);
+
+	mt792x_mutex_release(dev);
+}
+
 void mt7925_scan_work(struct work_struct *work)
 {
 	struct mt792x_phy *phy;
@@ -1508,6 +1560,7 @@ void mt7925_scan_work(struct work_struct *work)
 
 		while (tlv_len > 0 && le16_to_cpu(tlv->len) <= tlv_len) {
 			struct mt7925_mcu_scan_chinfo_event *evt;
+			struct mt76_connac_hw_scan_done *scan_done;
 
 			switch (le16_to_cpu(tlv->tag)) {
 			case UNI_EVENT_SCAN_DONE_BASIC:
@@ -1515,6 +1568,33 @@ void mt7925_scan_work(struct work_struct *work)
 					struct cfg80211_scan_info info = {
 						.aborted = false,
 					};
+					u16 len = le16_to_cpu(tlv->len);
+
+					scan_done = (struct mt76_connac_hw_scan_done *)tlv->data;
+					if (is_mt7927(&phy->dev->mt76) &&
+					    len >= sizeof(*tlv) +
+						   offsetof(struct mt76_connac_hw_scan_done,
+							    complete_channel_num) +
+						   sizeof(scan_done->complete_channel_num) &&
+					    !scan_done->complete_channel_num &&
+					    phy->scan_2ghz &&
+					    phy->scan_req && phy->scan_vif &&
+					    phy->scan_zero_complete_retries <
+					    MT7925_SCAN_RETRY_MAX) {
+						unsigned long delay;
+
+						phy->scan_zero_complete_retries++;
+						delay = msecs_to_jiffies(MT7925_SCAN_RETRY_MS);
+						ieee80211_queue_delayed_work(phy->mt76->hw,
+									     &phy->scan_retry_work,
+									     delay);
+						break;
+					}
+
+					phy->scan_req = NULL;
+					phy->scan_vif = NULL;
+					phy->scan_2ghz = false;
+					phy->scan_zero_complete_retries = 0;
 					ieee80211_scan_completed(phy->mt76->hw, &info);
 				}
 				break;
@@ -1544,11 +1624,31 @@ mt7925_hw_scan(struct ieee80211_hw *hw, struct ieee80211_vif *vif,
 	       struct ieee80211_scan_request *req)
 {
 	struct mt792x_dev *dev = mt792x_hw_dev(hw);
+	struct mt792x_phy *phy = mt792x_hw_phy(hw);
 	struct mt76_phy *mphy = hw->priv;
 	int err;
+	int i;
 
 	mt792x_mutex_acquire(dev);
+	phy->scan_req = req;
+	phy->scan_vif = vif;
+	phy->scan_2ghz = false;
+	phy->scan_zero_complete_retries = 0;
+
+	for (i = 0; i < req->req.n_channels; i++) {
+		if (req->req.channels[i]->band == NL80211_BAND_2GHZ) {
+			phy->scan_2ghz = true;
+			break;
+		}
+	}
+
 	err = mt7925_mcu_hw_scan(mphy, vif, req);
+	if (err) {
+		phy->scan_req = NULL;
+		phy->scan_vif = NULL;
+		phy->scan_2ghz = false;
+		phy->scan_zero_complete_retries = 0;
+	}
 	mt792x_mutex_release(dev);
 
 	return err;
@@ -1559,7 +1659,9 @@ mt7925_cancel_hw_scan(struct ieee80211_hw *hw, struct ieee80211_vif *vif)
 {
 	struct mt792x_dev *dev = mt792x_hw_dev(hw);
 	struct mt76_phy *mphy = hw->priv;
+	struct mt792x_phy *phy = mt792x_hw_phy(hw);
 
+	cancel_delayed_work_sync(&phy->scan_retry_work);
 	mt792x_mutex_acquire(dev);
 	mt7925_mcu_cancel_hw_scan(mphy, vif);
 	mt792x_mutex_release(dev);
@@ -1637,12 +1739,17 @@ static int mt7925_suspend(struct ieee80211_hw *hw,
 	struct mt792x_phy *phy = mt792x_hw_phy(hw);
 
 	cancel_delayed_work_sync(&phy->scan_work);
+	cancel_delayed_work_sync(&phy->scan_retry_work);
 	cancel_delayed_work_sync(&phy->mt76->mac_work);
 
 	cancel_delayed_work_sync(&dev->pm.ps_work);
 	mt76_connac_free_pending_tx_skbs(&dev->pm, NULL);
 
 	mt792x_mutex_acquire(dev);
+	if (phy->scan_req && phy->scan_vif)
+		mt7925_mcu_cancel_hw_scan(phy->mt76, phy->scan_vif);
+	else
+		mt7925_abort_scan(phy);
 
 	clear_bit(MT76_STATE_RUNNING, &phy->mt76->state);
 	ieee80211_iterate_active_interfaces(hw,

--- a/mt7925/main.c
+++ b/mt7925/main.c
@@ -2116,6 +2116,13 @@ static void mt7925_link_info_changed(struct ieee80211_hw *hw,
 	if (changed & BSS_CHANGED_CQM)
 		mt7925_mcu_set_rssimonitor(dev, vif);
 
+	if (changed & BSS_CHANGED_TXPOWER &&
+	    (!phy->txpower_set || info->txpower != phy->txpower)) {
+		phy->txpower = info->txpower;
+		phy->txpower_set = true;
+		mt7925_mcu_set_rate_txpower(phy->mt76);
+	}
+
 	mt792x_mutex_release(dev);
 }
 

--- a/mt7925/mcu.c
+++ b/mt7925/mcu.c
@@ -3314,6 +3314,7 @@ int mt7925_mcu_cancel_hw_scan(struct mt76_phy *phy,
 			      struct ieee80211_vif *vif)
 {
 	struct mt76_vif_link *mvif = (struct mt76_vif_link *)vif->drv_priv;
+	struct mt792x_phy *mphy = phy->priv;
 	struct {
 		struct scan_hdr {
 			u8 seq_num;
@@ -3337,13 +3338,9 @@ int mt7925_mcu_cancel_hw_scan(struct mt76_phy *phy,
 		},
 	};
 
-	if (test_and_clear_bit(MT76_HW_SCANNING, &phy->state)) {
-		struct cfg80211_scan_info info = {
-			.aborted = true,
-		};
-
-		ieee80211_scan_completed(phy->hw, &info);
-	}
+	cancel_delayed_work(&mphy->scan_retry_work);
+	if (test_bit(MT76_HW_SCANNING, &phy->state) || mphy->scan_req)
+		mt7925_abort_scan(mphy);
 
 	return mt76_mcu_send_msg(phy->dev, MCU_UNI_CMD(SCAN_REQ),
 				 &req, sizeof(req), true);

--- a/mt7925/mcu.c
+++ b/mt7925/mcu.c
@@ -3906,6 +3906,21 @@ int mt7925_mcu_set_rate_txpower(struct mt76_phy *phy)
 			return err;
 	}
 
+	if (phy->chandef.chan) {
+		struct mt76_power_limits la = {};
+		int tx_power;
+
+		tx_power = dev->phy.txpower_set ? dev->phy.txpower :
+						  mdev->hw->conf.power_level;
+		if (!tx_power)
+			tx_power = phy->chandef.chan->max_power;
+
+		tx_power = mt76_get_power_bound(phy, tx_power);
+		tx_power = mt76_get_rate_power_limits(phy, phy->chandef.chan,
+						      &la, tx_power);
+		phy->txpower_cur = tx_power;
+	}
+
 	return 0;
 }
 

--- a/mt7925/mt7925.h
+++ b/mt7925/mt7925.h
@@ -323,7 +323,9 @@ int mt7925_mcu_uni_rx_ba(struct mt792x_dev *dev,
 			 struct ieee80211_ampdu_params *params,
 			 struct ieee80211_vif *vif, bool enable);
 void mt7925_mlo_pm_work(struct work_struct *work);
+void mt7925_abort_scan(struct mt792x_phy *phy);
 void mt7925_scan_work(struct work_struct *work);
+void mt7925_scan_retry_work(struct work_struct *work);
 void mt7925_roc_work(struct work_struct *work);
 void mt7925_csa_work(struct work_struct *work);
 int mt7925_mcu_uni_bss_ps(struct mt792x_dev *dev,

--- a/mt7925/pci.c
+++ b/mt7925/pci.c
@@ -44,6 +44,7 @@ static void mt7925e_unregister_device(struct mt792x_dev *dev)
 		wiphy_rfkill_stop_polling(hw->wiphy);
 
 	cancel_work_sync(&dev->init_work);
+	cancel_delayed_work_sync(&dev->phy.scan_retry_work);
 	mt76_unregister_device(&dev->mt76);
 	mt76_for_each_q_rx(&dev->mt76, i)
 		napi_disable(&dev->mt76.napi[i]);

--- a/mt7925/usb.c
+++ b/mt7925/usb.c
@@ -342,11 +342,21 @@ MODULE_DEVICE_TABLE(usb, mt7925u_device_table);
 MODULE_FIRMWARE(MT7925_FIRMWARE_WM);
 MODULE_FIRMWARE(MT7925_ROM_PATCH);
 
+static void mt7925u_disconnect(struct usb_interface *usb_intf)
+{
+	struct mt792x_dev *dev = usb_get_intfdata(usb_intf);
+
+	if (dev)
+		cancel_delayed_work_sync(&dev->phy.scan_retry_work);
+
+	mt792xu_disconnect(usb_intf);
+}
+
 static struct usb_driver mt7925u_driver = {
 	.name		= KBUILD_MODNAME,
 	.id_table	= mt7925u_device_table,
 	.probe		= mt7925u_probe,
-	.disconnect	= mt792xu_disconnect,
+	.disconnect	= mt7925u_disconnect,
 #ifdef CONFIG_PM
 	.suspend	= mt7925u_suspend,
 	.resume		= mt7925u_resume,

--- a/mt792x.h
+++ b/mt792x.h
@@ -182,6 +182,11 @@ struct mt792x_phy {
 
 	struct sk_buff_head scan_event_list;
 	struct delayed_work scan_work;
+	struct ieee80211_scan_request *scan_req;
+	struct ieee80211_vif *scan_vif;
+	struct delayed_work scan_retry_work;
+	bool scan_2ghz;
+	u8 scan_zero_complete_retries;
 #ifdef CONFIG_ACPI
 	void *acpisar;
 #endif

--- a/mt792x.h
+++ b/mt792x.h
@@ -168,6 +168,9 @@ struct mt792x_phy {
 	s16 coverage_class;
 	u8 slottime;
 
+	int txpower;
+	bool txpower_set;
+
 	u32 rx_ampdu_ts;
 	u32 ampdu_ref;
 


### PR DESCRIPTION
Draft only / not for merge yet. This branch mirrors the MT7927 packet for maintainer-visible GitHub review before any canonical linux-wireless submission.

DCO state: these commits intentionally do not carry Signed-off-by yet. Darafei must review and certify DCO before this can become a ready-for-merge PR or an email submission.

Attribution: draft commits carry Assisted-by: OpenAI-Codex:gpt-5.

Scope in this standalone mt76 branch:
- Report configured/current TX power instead of transient 0 dBm before BSS txpower exists.
- Retry MT7927 2.4 GHz scans when firmware reports scan-done with complete_channel_num == 0 during Bluetooth Inquiry.
- DBDC is not included here because this openwrt/mt76 branch already enables MT7927 DBDC in mt7925 init/USB paths.

Local live evidence from the DKMS build installed on nucat:
- Loaded mt7925e module from /lib/modules/7.1-amd64/updates/dkms/mt7925e.ko.xz.
- iw dev wlp8s0 info reported txpower 23.00 dBm.
- Active BlueZ discovery reached Discovering: yes.
- Directed 2.4 GHz scan during discovery returned rc=0 and BSS_COUNT=2.

Checks on this GitHub branch:
- git diff --check HEAD~2..HEAD: clean.
- git mailinfo parses the generated patch stream.
- External module build against local 7.1-amd64 headers does not reach mt7925-specific compilation: standalone mt76 currently stops earlier in tx.c because ieee80211_txq_aql_pending is unavailable in the local header set.

Open question for the scan retry: maintainer feedback is requested on whether host-side delayed retry is acceptable, or whether this should become a firmware/coexistence-state fix instead.

Canonical submission note: Linux wireless still normally wants the DCO-reviewed email series routed through the mt76/wireless maintainers and lists; this draft PR is a staging artifact, not a substitute for that.