### PR TITLE
wifi: mt76: pass LED define via ccflags-y in driver submodules

### DIFF
--- a/mt7603/Makefile
+++ b/mt7603/Makefile
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause-Clear
-EXTRA_CFLAGS += -Werror -DCONFIG_MT76_LEDS
+ccflags-y += -Werror -DCONFIG_MT76_LEDS
 obj-m += mt7603e.o
 
 mt7603e-y := \

--- a/mt7615/Makefile
+++ b/mt7615/Makefile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-EXTRA_CFLAGS += -DCONFIG_MT76_LEDS
+ccflags-y += -DCONFIG_MT76_LEDS
 obj-$(CONFIG_MT7615_COMMON) += mt7615-common.o
 obj-$(CONFIG_MT7615E) += mt7615e.o
 obj-$(CONFIG_MT7663_USB_SDIO_COMMON) += mt7663-usb-sdio-common.o

--- a/mt7915/Makefile
+++ b/mt7915/Makefile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-EXTRA_CFLAGS += -DCONFIG_MT76_LEDS
+ccflags-y += -DCONFIG_MT76_LEDS
 obj-$(CONFIG_MT7915E) += mt7915e.o
 
 mt7915e-y := pci.o init.o dma.o eeprom.o main.o mcu.o mac.o \

--- a/mt7996/Makefile
+++ b/mt7996/Makefile
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
+ccflags-y += -DCONFIG_MT76_LEDS
 obj-$(CONFIG_MT7996E) += mt7996e.o
 
 mt7996e-y := pci.o init.o dma.o eeprom.o main.o mcu.o mac.o \


### PR DESCRIPTION
This PR fixes #1077.

Completes the EXTRA_CFLAGS → ccflags-y migration for `-DCONFIG_MT76_LEDS` that was started in d2b01fbc. That commit only touched the top-level `Makefile`, but `ccflags-y`/`EXTRA_CFLAGS` are scoped per kbuild makefile and aren't inherited by subdirectories.

I tested this by compiling https://github.com/openwrt/openwrt/commit/e4c35c2eec665f3f74a2b2f587fd2a1324b31841 with those changes for my D-Link DIR-882 A1 (has dual MT7615 radios); the `mt76-*` LED class devices now correctly appear under `/sys/class/leds`, the same behavior reported earlier in https://github.com/openwrt/mt76/issues/1077#issuecomment-4557037203 with a different router (but also using MT7615 radios).

The `mt7603`, `mt7915` and `mt7996` changes are the same fix applied for consistency, but I don't have hardware to test those.

`mt7996` in particular enables an `IS_ENABLED(CONFIG_MT76_LEDS)` code path that appears to have never been built with the define on before, so it'd be good if someone with that hardware could confirm it doesn't regress anything before merging. Alternatively, I can also drop the `mt7996` change from this PR and leave only the others...