### PR TITLE
wifi: mt76: mt7996: validate UNI PS sync events

### DIFF
--- a/mt7996/mcu.c
+++ b/mt7996/mcu.c
@@ -843,23 +843,32 @@ mt7996_mcu_rx_ps_sync(struct mt7996_dev *dev, struct sk_buff *skb)
 {
 	struct mt7996_mcu_ps_sync_event *event = (void *)skb->data;
 	struct tlv *tlv;
+	u16 tag = 0, tag_len = 0;
 	int len;
+
+	if (skb->len < sizeof(*event)) {
+		dev_warn_ratelimited(dev->mt76.dev,
+				     "short PS sync event: %u bytes\n",
+				     skb->len);
+		return;
+	}
 
 	skb_pull(skb, sizeof(*event));
 
 	len = skb->len;
-	while (len > sizeof(*tlv)) {
-		u16 tag, tag_len;
-
+	while (len >= sizeof(*tlv)) {
 		tlv = (struct tlv *)skb->data;
 		tag = le16_to_cpu(tlv->tag);
 		tag_len = le16_to_cpu(tlv->len);
-		if (tag_len > len)
-			break;
+		if (tag_len < sizeof(*tlv) || tag_len > len)
+			goto invalid;
 
 		switch (tag) {
 		case UNI_PS_CLIENT_INFO: {
 			struct mt7996_mcu_ps_client_info *info = (void *)tlv;
+
+			if (tag_len < sizeof(*info))
+				goto invalid;
 
 			mt7996_mcu_ps_transition(dev,
 						 le16_to_cpu(info->wlan_idx),
@@ -868,8 +877,16 @@ mt7996_mcu_rx_ps_sync(struct mt7996_dev *dev, struct sk_buff *skb)
 		}
 		case UNI_PS_MULTI_CLIENT_INFO: {
 			struct mt7996_mcu_ps_multi_client_info *info = (void *)tlv;
-			u16 cnt = le16_to_cpu(info->sta_cnt);
+			u16 cnt;
 			int i;
+
+			if (tag_len < sizeof(*info))
+				goto invalid;
+
+			cnt = le16_to_cpu(info->sta_cnt);
+			if (cnt > (tag_len - sizeof(*info)) /
+				  sizeof(info->sta_ps_info[0]))
+				goto invalid;
 
 			for (i = 0; i < cnt; i++) {
 				u16 entry = le16_to_cpu(info->sta_ps_info[i]);
@@ -895,6 +912,13 @@ mt7996_mcu_rx_ps_sync(struct mt7996_dev *dev, struct sk_buff *skb)
 		skb_pull(skb, tag_len);
 		len -= tag_len;
 	}
+
+	return;
+
+invalid:
+	dev_warn_ratelimited(dev->mt76.dev,
+			     "invalid PS sync TLV: tag=%u len=%u remaining=%d\n",
+			     tag, tag_len, len);
 }
 
 static void


### PR DESCRIPTION
## Summary

- validate the PS sync event header before pulling it
- reject zero-length, truncated and oversized TLVs
- validate the variable-length multi-client station array
- rate-limit warnings for malformed events

## Failure mode

This was reproduced on a Gemtek XR1710G using MT7996 with three-link
MLO enabled.

A firmware `MCU_UNI_EVENT_PS_SYNC` event left 7 bytes after the event
header and reported a TLV length of 0. The parser accepted it and
repeated:

    skb_pull(skb, 0);
    len -= 0;

The threaded `napi/phy0-0` poller therefore never made progress. It
eventually starved the RCU grace-period kthread and made all wireless
bands unresponsive.

In the reproducing build, the register state was `x24=7` for the
remaining length and `x23=0` for `tag_len`. The return address
`mt7996_mcu_rx_event+0x3f0` maps to the `skb_pull()` call in the
PS sync TLV loop.

## Validation

- Linux `checkpatch.pl --strict`: no errors or warnings
- `make package/kernel/mt76/compile V=s`
- complete ImmortalWrt XR1710G AP firmware build
- verified that the resulting `mt7996e.ko` contains the new validation
  and rate-limited warning paths
