### PR TITLE
wifi: mt76: clean up station WCID and TX queues before sta_remove

### DIFF
--- a/mac80211.c
+++ b/mac80211.c
@@ -1635,10 +1635,10 @@ void __mt76_sta_remove(struct mt76_phy *phy, struct ieee80211_vif *vif,
 	for (i = 0; i < ARRAY_SIZE(wcid->aggr); i++)
 		mt76_rx_aggr_stop(dev, wcid, i);
 
+	mt76_wcid_cleanup(dev, wcid);
+
 	if (dev->drv->sta_remove)
 		dev->drv->sta_remove(dev, vif, sta);
-
-	mt76_wcid_cleanup(dev, wcid);
 
 	mt76_wcid_mask_clear(dev->wcid_mask, idx);
 	phy->num_sta--;


### PR DESCRIPTION
When a station is removed, __mt76_sta_remove() previously called dev->drv->sta_remove() before calling mt76_wcid_cleanup().

Because dev->drv->sta_remove() informs the hardware/firmware that the station's WCID is released, having un-transmitted packets in wcid->tx_pending/tx_offchannel or having the station still present on phy->tx_list during or after sta_remove can cause concurrent TX workers to attempt transmission on an unassigned/freed hardware WCID.

Move mt76_wcid_cleanup() before dev->drv->sta_remove() so that TX polling and scheduling are halted under phy->tx_lock and all pending TX frames are cleanly flushed via ieee80211_free_txskb() before the hardware/firmware is notified.