### PR TITLE
wifi: mt76: mt7996: properly disable in-band discovery when interval is 0

### DIFF
--- a/mt7996/mcu.c
+++ b/mt7996/mcu.c
@@ -3429,6 +3429,31 @@ out:
 				     MCU_WMWA_UNI_CMD(BSS_INFO_UPDATE), true);
 }
 
+static int
+mt7996_mcu_beacon_inband_discov_disable(struct mt7996_dev *dev,
+				       struct mt7996_vif_link *link,
+				       u32 changed)
+{
+	struct bss_inband_discovery_tlv *discov;
+	struct sk_buff *rskb;
+	struct tlv *tlv;
+
+	rskb = __mt7996_mcu_alloc_bss_req(&dev->mt76, &link->mt76,
+					  sizeof(*discov) + sizeof(*tlv));
+	if (IS_ERR(rskb))
+		return PTR_ERR(rskb);
+
+	tlv = mt7996_mcu_add_uni_tlv(rskb, UNI_BSS_INFO_OFFLOAD, sizeof(*discov));
+	discov = (struct bss_inband_discovery_tlv *)tlv;
+	discov->tx_mode = OFFLOAD_TX_MODE_SU;
+	/* 0: UNSOL PROBE RESP, 1: FILS DISCOV */
+	discov->tx_type = (changed & BSS_CHANGED_FILS_DISCOVERY) ? 1 : 0;
+	discov->wcid = cpu_to_le16(MT7996_WTBL_RESERVED);
+
+	return mt76_mcu_skb_send_msg(&dev->mt76, rskb,
+				     MCU_WMWA_UNI_CMD(BSS_INFO_UPDATE), true);
+}
+
 int mt7996_mcu_beacon_inband_discov(struct mt7996_dev *dev,
 				    struct ieee80211_bss_conf *link_conf,
 				    struct mt7996_vif_link *link, u32 changed)
@@ -3445,7 +3470,7 @@ int mt7996_mcu_beacon_inband_discov(struct mt7996_dev *dev,
 	struct cfg80211_chan_def *chandef;
 	enum nl80211_band band;
 	struct tlv *tlv;
-	u8 *buf, interval;
+	u8 *buf, interval = 0;
 	int len;
 
 	if (!mphy)
@@ -3457,26 +3482,29 @@ int mt7996_mcu_beacon_inband_discov(struct mt7996_dev *dev,
 	if (link_conf->nontransmitted)
 		return 0;
 
-	rskb = __mt7996_mcu_alloc_bss_req(&dev->mt76, &link->mt76,
-					  MT7996_MAX_BSS_OFFLOAD_SIZE);
-	if (IS_ERR(rskb))
-		return PTR_ERR(rskb);
-
-	if (changed & BSS_CHANGED_FILS_DISCOVERY &&
-	    link_conf->fils_discovery.max_interval) {
+	if (changed & BSS_CHANGED_FILS_DISCOVERY) {
 		interval = link_conf->fils_discovery.max_interval;
-		skb = ieee80211_get_fils_discovery_tmpl(hw, vif,
-							link_conf->link_id);
-	} else if (changed & BSS_CHANGED_UNSOL_BCAST_PROBE_RESP &&
-		   link_conf->unsol_bcast_probe_resp_interval) {
-		interval = link_conf->unsol_bcast_probe_resp_interval;
-		skb = ieee80211_get_unsol_bcast_probe_resp_tmpl(hw, vif,
+		if (interval)
+			skb = ieee80211_get_fils_discovery_tmpl(hw, vif,
 								link_conf->link_id);
+	} else if (changed & BSS_CHANGED_UNSOL_BCAST_PROBE_RESP) {
+		interval = link_conf->unsol_bcast_probe_resp_interval;
+		if (interval)
+			skb = ieee80211_get_unsol_bcast_probe_resp_tmpl(hw, vif,
+									link_conf->link_id);
 	}
 
-	if (!skb) {
-		dev_kfree_skb(rskb);
+	if (!interval)
+		return mt7996_mcu_beacon_inband_discov_disable(dev, link, changed);
+
+	if (!skb)
 		return -EINVAL;
+
+	rskb = __mt7996_mcu_alloc_bss_req(&dev->mt76, &link->mt76,
+					  MT7996_MAX_BSS_OFFLOAD_SIZE);
+	if (IS_ERR(rskb)) {
+		dev_kfree_skb(skb);
+		return PTR_ERR(rskb);
 	}
 
 	if (skb->len > MT7996_MAX_BEACON_SIZE) {


### PR DESCRIPTION
When in-band discovery (FILS discovery or unsolicited broadcast probe responses) is disabled (interval set to 0), mac80211 frees the frame template and sends BSS_CHANGED_FILS_DISCOVERY / BSS_CHANGED_UNSOL_BCAST_PROBE_RESP.

In mt7996_mcu_beacon_inband_discov(), the driver checked if the interval was non-zero before fetching the template. If interval is 0, skb remained NULL. The subsequent `if (!skb)` check returned -EINVAL immediately, preventing the driver from sending the BSS_INFO_UPDATE MCU command with discov->enable = false to the firmware.

As a result, the hardware continued transmitting in-band discovery frames indefinitely.

Fix this by introducing mt7996_mcu_beacon_inband_discov_disable() to send a dedicated BSS_INFO_INBAND_DISCOVERY TLV with enable = false when in-band discovery is disabled, and defer the large BSS offload request allocation until after validating the interval and template.

Verified on BPi-R4 with that patch.  Run wifi-iface with fils_discovery.max_interval=20, update it to 0 and reload wifi, observe in pcap that there are no frames. Reset to 20 and reload wifi, frames start broadcasting.
